### PR TITLE
Throw exception on enum ordinal change

### DIFF
--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/exceptions/PersistenceExceptionTypeConsistencyEnum.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/exceptions/PersistenceExceptionTypeConsistencyEnum.java
@@ -1,0 +1,48 @@
+package org.eclipse.serializer.persistence.exceptions;
+
+/*-
+ * #%L
+ * Eclipse Serializer Persistence
+ * %%
+ * Copyright (C) 2023 Eclipse Foundation
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+public class PersistenceExceptionTypeConsistencyEnum extends PersistenceExceptionConsistency
+{
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	public PersistenceExceptionTypeConsistencyEnum(final String constantName, final String enumClassName, final int ordinal, final long targetOrdinal)
+	{
+		super(
+			buildMessage(
+				constantName,
+				enumClassName,
+				ordinal,
+				targetOrdinal
+		));
+	}
+
+	private static String buildMessage(final String constantName, final String enumClassName, final int ordinal, final long targetOrdinal)
+	{
+		return "The ordinal of the enum constant " + constantName + " of " +
+			enumClassName +
+			"\nwould be change by the legacy type mapping from " +
+			ordinal + " to " + targetOrdinal + ". This may cause the storage becoming corrupted." +
+			"\nIf the ordinal change is intended you need to define a manual legacy type mapping!";
+	}
+}

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceLegacyTypeHandlerCreator.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceLegacyTypeHandlerCreator.java
@@ -1,8 +1,5 @@
 package org.eclipse.serializer.persistence.types;
 
-import org.eclipse.serializer.persistence.exceptions.PersistenceException;
-import org.slf4j.Logger;
-
 import org.eclipse.serializer.chars.XChars;
 
 /*-
@@ -26,9 +23,12 @@ import org.eclipse.serializer.chars.XChars;
  */
 
 import org.eclipse.serializer.collections.BulkList;
+import org.eclipse.serializer.persistence.exceptions.PersistenceException;
+import org.eclipse.serializer.persistence.exceptions.PersistenceExceptionTypeConsistencyEnum;
 import org.eclipse.serializer.reflect.XReflect;
 import org.eclipse.serializer.util.logging.Logging;
 import org.eclipse.serializer.util.similarity.Similarity;
+import org.slf4j.Logger;
 
 public interface PersistenceLegacyTypeHandlerCreator<D>
 {
@@ -83,8 +83,23 @@ public interface PersistenceLegacyTypeHandlerCreator<D>
 				{
 					final PersistenceTypeDefinitionMember targetCurrentConstant = match.targetElement();
 					final long targetOrdinal = currentConstantMembers.indexOf(targetCurrentConstant);
+					
 					if(targetOrdinal >= 0)
 					{
+						//allow ordinal changes only by explicit manual mappings
+						if(targetOrdinal != ordinal)
+						{
+							if(match.similarity() != PersistenceLegacyTypeMapper.Defaults.defaultExplicitMappingSimilarity())
+							{
+								throw new PersistenceExceptionTypeConsistencyEnum(
+									targetCurrentConstant.identifier(),
+									result.currentTypeHandler().typeName(),
+									ordinal,
+									targetOrdinal
+								);
+							}
+						}
+						
 						ordinalMap[ordinal] = Integer.valueOf((int)targetOrdinal);
 					}
 					else


### PR DESCRIPTION
Throw an PersistenceExceptionTypeConsistencyEnum if the automatic legacy type mapping would change the ordinal of an enum constant.