### PR TITLE
disable info log output into console during maven build

### DIFF
--- a/tests/integration-jdk17/src/test/resources/simplelogger.properties
+++ b/tests/integration-jdk17/src/test/resources/simplelogger.properties
@@ -1,0 +1,5 @@
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+
+org.slf4j.simpleLogger.defaultLogLevel=warn

--- a/tests/integration/src/test/resources/simplelogger.properties
+++ b/tests/integration/src/test/resources/simplelogger.properties
@@ -1,0 +1,5 @@
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+
+org.slf4j.simpleLogger.defaultLogLevel=warn


### PR DESCRIPTION
disable info log output into console during maven build