### PR TITLE
Configure Branch-Specific Snapshot Deployment for Java 11 and 17

### DIFF
--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   publish:
-    if: github.repository == 'eclipse-store/store'
+    if: github.repository == 'eclipse-store/serializer'
     runs-on: ubuntu-latest
     steps:
       - id: install-secret-key

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -1,0 +1,105 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Make branch snapshot and deploy
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - 'release/**'
+
+jobs:
+  publish:
+    if: github.repository == 'eclipse-store/store'
+    runs-on: ubuntu-latest
+    steps:
+      - id: install-secret-key
+        name: Install gpg secret key
+        run: |
+          cat <(echo -e "${{ secrets.ORG_GPG_PRIVATE_KEY }}") | gpg --batch --import
+          gpg --list-secret-keys --keyid-format LONG
+      - uses: actions/checkout@v3
+      - name: Set up Java for publishing to Maven Central Snapshot Repository
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-passphrase: PASSPHRASE
+      - name: Prepare suffix
+        run: |
+          function prepareSuffix() {
+            local branch=$1
+            local result=${branch//\//_}
+            result=${result//#/}
+            local maxLength=10
+            if (( ${#result} > maxLength )); then
+              result=${result:0:maxLength}
+            fi
+            local hashFromContent=$(echo -n "$branch" | md5sum | cut -f1 -d" ")
+            echo "${result}-${hashFromContent:0:10}"
+          }
+          suffix=$(prepareSuffix ${GITHUB_REF#refs/heads/})
+          echo "Suffix: $suffix"
+          echo "SUFFIX=$suffix" >> $GITHUB_ENV
+      - name: Update project version
+        run: |
+          currentVersion=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+          currentVersionWithoutSnapshot=${currentVersion%-SNAPSHOT}
+          newVersion="${currentVersionWithoutSnapshot}-$SUFFIX-SNAPSHOT"
+          mvn versions:set -DnewVersion=$newVersion --batch-mode
+      - name: Make a snapshot
+        run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy -U
+        env:
+          MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
+          PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+
+        #java 17 build
+      - uses: actions/checkout@v3
+      - name: Set up Java for publishing to Maven Central Snapshot Repository
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-passphrase: PASSPHRASE
+      - name: Prepare suffix
+        run: |
+          function prepareSuffix() {
+            local branch=$1
+            local result=${branch//\//_}
+            result=${result//#/}
+            local maxLength=10
+            if (( ${#result} > maxLength )); then
+              result=${result:0:maxLength}
+            fi
+            local hashFromContent=$(echo -n "$branch" | md5sum | cut -f1 -d" ")
+            echo "${result}-${hashFromContent:0:10}"
+          }
+          suffix=$(prepareSuffix ${GITHUB_REF#refs/heads/})
+          echo "Suffix: $suffix"
+          echo "SUFFIX=$suffix" >> $GITHUB_ENV
+      - name: Update project version java 17
+        run: |
+          currentVersion=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+          currentVersionWithoutSnapshot=${currentVersion%-SNAPSHOT}
+          newVersion="${currentVersionWithoutSnapshot}-$SUFFIX-SNAPSHOT"
+          mvn versions:set -DnewVersion=$newVersion --batch-mode
+      - name: Make a snapshot java 17
+        run: |
+          mvn -pl persistence/binary-jdk17 clean install -am -B
+      - name: Deploy module build with java 17
+        run: |
+          mvn -Pdeploy -pl persistence/binary-jdk17 deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
+          PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   publish:
-    if: github.repository == 'eclipse-store/serializer'
+    if: github.repository == 'eclipse-serializer/serializer'
     runs-on: ubuntu-latest
     steps:
       - id: install-secret-key


### PR DESCRIPTION
This pull request introduces changes to the Maven deployment workflow for snapshot builds in the development environment. The changes include:

- Configuring the workflow to ignore the `main` and `release/**` branches.
- Setting up Java 11 and 17 environments for publishing to the Maven Central Snapshot Repository.
- Implementing a function to prepare a unique suffix based on the branch name and its MD5 hash.
- Updating the project version to include the unique suffix.
- Running the Maven `deploy` command to create and deploy the snapshot.
- Repeating the above steps specifically for a Java 17 build.

These changes aim to streamline the snapshot deployment process and ensure that each snapshot is uniquely identifiable by its version number.