### PR TITLE
Revert "create artifact during PR (#94)"

### DIFF
--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -8,8 +8,6 @@ on:
     branches-ignore:
       - main
       - 'release/**'
-  pull_request:
-    branches: [ main ]
 
 jobs:
   publish:


### PR DESCRIPTION
Unfortunately, it doesn't work the way I need it to. For branches existing in this repository it works, but I don't need it because I already have an artifact from that branch and for foreign ones it takes security from their repository so it's not able to deploy the artifact. 