### PR TITLE
Add resolvePath to AFileSystem

### DIFF
--- a/afs/afs/src/main/java/org/eclipse/serializer/afs/types/AFileSystem.java
+++ b/afs/afs/src/main/java/org/eclipse/serializer/afs/types/AFileSystem.java
@@ -125,6 +125,11 @@ public interface AFileSystem extends AResolving, WriteController
 		return this.buildPath((AItem)directory);
 	}
 	
+	public default String[] resolvePath(final String fullPath)
+	{
+		return fullPath.split("[/\\\\]");
+	}
+	
 	
 	public String getFileName(AFile file);
 	


### PR DESCRIPTION
Utility to split a single String into a path elements String[].