### PR TITLE
Fixing #204 foundation type handler registration depends on order of api calls

### DIFF
--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceCustomTypeHandlerRegistry.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceCustomTypeHandlerRegistry.java
@@ -22,6 +22,8 @@ import org.eclipse.serializer.collections.HashEnum;
 import org.eclipse.serializer.collections.HashTable;
 import org.eclipse.serializer.collections.types.XGettingCollection;
 import org.eclipse.serializer.collections.types.XGettingEnum;
+import org.eclipse.serializer.util.logging.Logging;
+import org.slf4j.Logger;
 
 public interface PersistenceCustomTypeHandlerRegistry<D> extends PersistenceTypeHandlerIterable<D>
 {
@@ -54,6 +56,14 @@ public interface PersistenceCustomTypeHandlerRegistry<D> extends PersistenceType
 
 	public final class Default<D> implements PersistenceCustomTypeHandlerRegistry<D>
 	{
+		///////////////////////////////////////////////////////////////////////////
+		// constants //
+		//////////////
+		
+		final static Logger logger = Logging.getLogger(PersistenceCustomTypeHandlerRegistry.class);
+
+		
+		
 		///////////////////////////////////////////////////////////////////////////
 		// instance fields //
 		////////////////////
@@ -120,7 +130,10 @@ public interface PersistenceCustomTypeHandlerRegistry<D> extends PersistenceType
 			final PersistenceTypeHandler<D, ? super T> typeHandlerInitializer
 		)
 		{
-			// put instead of add to allow custom-tailored replacments for native handlers (e.g. divergent TID or logic)
+			// put instead of add to allow custom-tailored replacements for native handlers (e.g. divergent TID or logic)
+			
+			logger.info("Registering type handler {} for type {}", typeHandlerInitializer.getClass(), type);
+			
 			return this.liveTypeHandlers.put(
 				notNull(type),
 				notNull(typeHandlerInitializer)
@@ -145,6 +158,8 @@ public interface PersistenceCustomTypeHandlerRegistry<D> extends PersistenceType
 			final PersistenceLegacyTypeHandler<D, T> legacyTypeHandler
 		)
 		{
+			logger.info("Registering legacy type handler {} for type {}", legacyTypeHandler.getClass(), legacyTypeHandler.typeName());
+			
 			return this.legacyTypeHandlers.add(legacyTypeHandler);
 		}
 		

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceFoundation.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceFoundation.java
@@ -602,6 +602,12 @@ extends Cloneable<PersistenceFoundation<D, F>>,
 			final PersistenceTypeHandler<D, ?> customTypeHandler
 		)
 		{
+			//if already existing register handler directly
+			if(this.customTypeHandlerRegistry != null) {
+				this.customTypeHandlerRegistry.registerTypeHandler(customTypeHandler);
+				//do not return, add to customTypeHandlers table for sake of completeness
+			}
+			
 			this.customTypeHandlers.put(customTypeHandler.type(), customTypeHandler);
 			return this.$();
 		}

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceFoundation.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceFoundation.java
@@ -602,7 +602,7 @@ extends Cloneable<PersistenceFoundation<D, F>>,
 			final PersistenceTypeHandler<D, ?> customTypeHandler
 		)
 		{
-			//if already existing register handler directly
+			//if registry already existing register handler directly
 			if(this.customTypeHandlerRegistry != null) {
 				this.customTypeHandlerRegistry.registerTypeHandler(customTypeHandler);
 				//do not return, add to customTypeHandlers table for sake of completeness


### PR DESCRIPTION
The registerTypeHandler and registerCustomTypeHandler simply collect all passed handlers. Thay are registered later when the registry is created. 
The fix checks if the registry is already create and registers the passed handler if necessary.

fixes eclipse-store/store#204