### PR TITLE
update README.md to v. 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Classes evolve over time. Therefore, Eclipse Serializer provides a legacy type m
 <dependency>
   <groupId>org.eclipse.serializer</groupId>
   <artifactId>serializer</artifactId>
-  <version>1.3.2</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the version of the `org.eclipse.serializer` dependency from `1.3.2` to `2.0.0`.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R52): Updated the `org.eclipse.serializer` dependency version to `2.0.0`.