### PR TITLE
fixed jmx bean naming

### DIFF
--- a/base/src/main/java/org/eclipse/serializer/monitoring/MonitoringManager.java
+++ b/base/src/main/java/org/eclipse/serializer/monitoring/MonitoringManager.java
@@ -84,6 +84,25 @@ public interface MonitoringManager
 		
 		return JMX();
 	}
+	
+	/**
+	 * Provide a platform dependent MonitoringManager.
+	 * This is either the "JMX" implementation or the "Disabled" implementation
+	 * on android systems.
+	 * 
+	 * This method does not create a storage specific name.
+	 * 
+	 * @return a platform dependent MonitoringManage instance
+	 */
+	public static MonitoringManager PlatformDependent()
+	{
+		if(VMInfo.New().isAnyAndroid())
+		{
+			return Disabled();
+		}
+						
+		return JMX(null);
+	}
 		
 	/**
 	 * Provides a new instance of the default JMX MonitoringManager implementation.
@@ -155,6 +174,8 @@ public interface MonitoringManager
 		{
 			super();
 			this.storageName = storageName;
+			
+			logger.debug("create MonitoringManager for storage: " + this.storageName);
 		}
 		
 		

--- a/base/src/main/java/org/eclipse/serializer/reference/LazyReferenceManager.java
+++ b/base/src/main/java/org/eclipse/serializer/reference/LazyReferenceManager.java
@@ -152,7 +152,7 @@ public interface LazyReferenceManager
 			checker,
 			_longReference.New(milliTimeCheckInterval),
 			_longReference.New(nanoTimeBudget)        ,
-			MonitoringManager.PlatformDependent(null)
+			MonitoringManager.PlatformDependent()
 		);
 	}
 	


### PR DESCRIPTION
fixed JMX bean naming hierarchy in for the LazyReferenceManager bean
the naming error was caused by #154 