### PR TITLE
Zj/maven plugin update 090125

### DIFF
--- a/base/src/main/java/org/eclipse/serializer/io/XIO.java
+++ b/base/src/main/java/org/eclipse/serializer/io/XIO.java
@@ -1419,7 +1419,7 @@ public final class XIO
 	 * @param targetPosition target write start position
 	 * @param length         number of bytes to copy
 	 * @return               number of bytes written
-	 * @throws IOException
+	 * @throws IOException   if an I/O error occurs during the file copy operation
 	 */
 	public static long copyFile(
 		final FileChannel sourceChannel ,

--- a/base/src/main/java/org/eclipse/serializer/io/XIO.java
+++ b/base/src/main/java/org/eclipse/serializer/io/XIO.java
@@ -1377,7 +1377,7 @@ public final class XIO
 	 * @param length         number of bytes to copy
 	 * @param targetChannel  target channel
 	 * @return               number of bytes written
-	 * @throws IOException
+	 * @throws IOException   if an I/O error occurs during the file copy operation
 	 */
 	public static long copyFile(
 		final FileChannel sourceChannel ,

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceStorer.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceStorer.java
@@ -115,6 +115,7 @@ public interface PersistenceStorer extends Storer
 		 * @param objectRetriever the provided object retriever
 		 * @param target the provided persistence target
 		 * @param bufferSizeProvider the provided buffer size provider
+		 * @param persister the provided persister
 		 * @return a new eager storer
 		 */
 		public PersistenceStorer createEagerStorer(

--- a/pom.xml
+++ b/pom.xml
@@ -385,10 +385,10 @@
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
 					</plugin>
-<!--					<plugin>-->
-<!--						<groupId>org.apache.maven.plugins</groupId>-->
-<!--						<artifactId>maven-gpg-plugin</artifactId>-->
-<!--					</plugin>-->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-dependency-plugin</artifactId>
-					<version>3.6.1</version>
+					<version>3.8.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.felix</groupId>
@@ -190,7 +190,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.8.0</version>
+					<version>3.10.0</version>
 					<configuration>
 						<failOnError>${javadoc.failed.on.error}</failOnError>
 						<notree>true</notree>
@@ -236,7 +236,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-gpg-plugin</artifactId>
-					<version>3.2.4</version>
+					<version>3.2.6</version>
 					<executions>
 						<execution>
 							<id>sign-artifacts</id>
@@ -301,7 +301,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-site-plugin</artifactId>
-					<version>4.0.0-M13</version>
+					<version>4.0.0-M16</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -311,7 +311,7 @@
 				<plugin>
 					<groupId>org.cyclonedx</groupId>
 					<artifactId>cyclonedx-maven-plugin</artifactId>
-					<version>2.7.11</version>
+					<version>2.8.1</version>
 					<executions>
 						<execution>
 							<phase>prepare-package</phase>
@@ -385,10 +385,10 @@
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
 					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-					</plugin>
+<!--					<plugin>-->
+<!--						<groupId>org.apache.maven.plugins</groupId>-->
+<!--						<artifactId>maven-gpg-plugin</artifactId>-->
+<!--					</plugin>-->
 				</plugins>
 			</build>
 		</profile>


### PR DESCRIPTION
This pull request includes several updates to improve documentation and upgrade dependencies. The most important changes are grouped into documentation improvements and dependency upgrades.

Documentation improvements:

* [`base/src/main/java/org/eclipse/serializer/io/XIO.java`](diffhunk://#diff-fe28ff03088bfe8c71ceda5ee5e908a3fd855dfff189a64f564e29c7a28feaaeL1380-R1380): Updated the `@throws IOException` documentation in the `copyFile` method to include a description of the I/O error. [[1]](diffhunk://#diff-fe28ff03088bfe8c71ceda5ee5e908a3fd855dfff189a64f564e29c7a28feaaeL1380-R1380) [[2]](diffhunk://#diff-fe28ff03088bfe8c71ceda5ee5e908a3fd855dfff189a64f564e29c7a28feaaeL1422-R1422)

Dependency upgrades:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L132-R132): Upgraded `maven-dependency-plugin` from version 3.6.1 to 3.8.0.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L193-R193): Upgraded `maven-javadoc-plugin` from version 3.8.0 to 3.10.0.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L239-R239): Upgraded `maven-gpg-plugin` from version 3.2.4 to 3.2.6.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L304-R304): Upgraded `maven-site-plugin` from version 4.0.0-M13 to 4.0.0-M16.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L314-R314): Upgraded `cyclonedx-maven-plugin` from version 2.7.11 to 2.8.1.

Additionally, a new parameter `persister` was added to the `createEagerStorer` javadoc in `persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceStorer.java`.