### PR TITLE
fix javadoc warning

### DIFF
--- a/serializer/src/main/java/org/eclipse/serializer/Serializer.java
+++ b/serializer/src/main/java/org/eclipse/serializer/Serializer.java
@@ -87,6 +87,7 @@ public interface Serializer<M> extends AutoCloseable
 	
 	/**
 	 * @deprecated typo, replaced by {@link #exportTypeDictionary()}, will be removed in a future release
+	 * @return type dictionary as String.
 	 */
 	@Deprecated(forRemoval = true)
 	public default String exportTypeDictionay()


### PR DESCRIPTION
This is deprecated, for remove. But it raises a Javadoc Warning. So I added the return comment to eliminate this message in build logs. 