### PR TITLE
Develocity integration

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -26,6 +26,8 @@ jobs:
         cache: 'maven'
     - name: Build with Maven
       run: mvn -B package --file pom.xml
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       #Build with java 17
     - uses: actions/checkout@v3
@@ -36,4 +38,6 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml      
+      run: mvn -B package --file pom.xml
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}

--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -25,7 +25,7 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B clean package --file pom.xml
       env:
         DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
@@ -38,6 +38,6 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B clean package --file pom.xml
       env:
         DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}

--- a/.github/workflows/maven_build_win.yml
+++ b/.github/workflows/maven_build_win.yml
@@ -26,6 +26,8 @@ jobs:
         cache: 'maven'
     - name: Build with Maven
       run: mvn -B package --file pom.xml
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       #Build with java 17
     - uses: actions/checkout@v3
@@ -36,4 +38,6 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml      
+      run: mvn -B package --file pom.xml
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}

--- a/.github/workflows/maven_build_win.yml
+++ b/.github/workflows/maven_build_win.yml
@@ -25,7 +25,7 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B clean package --file pom.xml
       env:
         DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
@@ -38,6 +38,6 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B clean package --file pom.xml
       env:
         DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}

--- a/.github/workflows/maven_deploy_snapshot.yml
+++ b/.github/workflows/maven_deploy_snapshot.yml
@@ -57,7 +57,7 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl persistence/binary-jdk17 deploy -Dscan.value.profile="deploy" -Dscan.value.project="binary-jdk17"
+          mvn -Pdeploy -pl persistence/binary-jdk17 clean deploy -Dscan.value.profile="deploy" -Dscan.value.project="binary-jdk17"
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}

--- a/.github/workflows/maven_deploy_snapshot.yml
+++ b/.github/workflows/maven_deploy_snapshot.yml
@@ -31,11 +31,12 @@ jobs:
           server-password: MAVEN_PASSWORD
           gpg-passphrase: PASSPHRASE
       - name: Make a snapshot
-        run: mvn -Pdeploy --no-transfer-progress --batch-mode clean deploy
+        run: mvn -Pdeploy --no-transfer-progress --batch-mode clean deploy -Dscan.value.profile="deploy"
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
           PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       #java 17 build
       - uses: actions/checkout@v3
@@ -51,11 +52,14 @@ jobs:
           gpg-passphrase: PASSPHRASE
       - name: Build with java 17
         run: |
-          mvn -pl persistence/binary-jdk17 clean install -am -B
+          mvn -pl persistence/binary-jdk17 clean install -am -B -Dscan.value.project="binary-jdk17"
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl persistence/binary-jdk17 deploy
+          mvn -Pdeploy -pl persistence/binary-jdk17 deploy -Dscan.value.profile="deploy" -Dscan.value.project="binary-jdk17"
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
           PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -101,7 +101,7 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl persistence/binary-jdk17 deploy -Dscan.value.profile="deploy" -Dscan.value.project="binary-jdk17"
+          mvn -Pdeploy -pl persistence/binary-jdk17 clean deploy -Dscan.value.profile="deploy" -Dscan.value.project="binary-jdk17"
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -53,11 +53,12 @@ jobs:
           newVersion="${currentVersionWithoutSnapshot}-$SUFFIX-SNAPSHOT"
           mvn versions:set -DnewVersion=$newVersion --batch-mode
       - name: Make a snapshot
-        run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy -U
+        run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy -U -Dscan.value.profile="deploy,production"
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
           PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
         #java 17 build
       - uses: actions/checkout@v3
@@ -95,11 +96,14 @@ jobs:
           mvn versions:set -DnewVersion=$newVersion --batch-mode
       - name: Make a snapshot java 17
         run: |
-          mvn -pl persistence/binary-jdk17 clean install -am -B
+          mvn -pl persistence/binary-jdk17 clean install -am -B -Dscan.value.project="binary-jdk17"
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl persistence/binary-jdk17 deploy
+          mvn -Pdeploy -pl persistence/binary-jdk17 deploy -Dscan.value.profile="deploy" -Dscan.value.project="binary-jdk17"
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
           PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}

--- a/.github/workflows/maven_javadoc.yml
+++ b/.github/workflows/maven_javadoc.yml
@@ -25,7 +25,9 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -P javadoc-check -B package --file pom.xml
+      run: mvn -P javadoc-check -B package --file pom.xml -Dscan.value.profile=javadoc-check
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       #Build with java 17
     - uses: actions/checkout@v3
@@ -36,4 +38,6 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -P javadoc-check -B package --file pom.xml
+      run: mvn -P javadoc-check -B package --file pom.xml -Dscan.value.profile=javadoc-check
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}

--- a/.github/workflows/maven_javadoc.yml
+++ b/.github/workflows/maven_javadoc.yml
@@ -25,7 +25,7 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -P javadoc-check -B package --file pom.xml -Dscan.value.profile=javadoc-check
+      run: mvn -P javadoc-check -B clean package --file pom.xml -Dscan.value.profile=javadoc-check
       env:
         DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
@@ -38,6 +38,6 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -P javadoc-check -B package --file pom.xml -Dscan.value.profile=javadoc-check
+      run: mvn -P javadoc-check -B clean package --file pom.xml -Dscan.value.profile=javadoc-check
       env:
         DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -30,12 +30,15 @@ jobs:
           gpg-passphrase: PASSPHRASE
       - name: Maven change version
         run: mvn versions:set -DnewVersion=${{ github.event.release.tag_name }} --batch-mode
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Make a release
-        run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy
+        run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy -Dscan.value.profile="deploy,production"
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
           PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       #java 17 build
       - uses: actions/checkout@v3
@@ -51,13 +54,18 @@ jobs:
           gpg-passphrase: PASSPHRASE
       - name: Maven change version
         run: mvn versions:set -DnewVersion=${{ github.event.release.tag_name }} --batch-mode
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Build with java 17
         run: |
-          mvn -pl persistence/binary-jdk17 clean install -am -B
+          mvn -pl persistence/binary-jdk17 clean install -am -B -Dscan.value.project="binary-jdk17"
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl persistence/binary-jdk17 deploy
+          mvn -Pdeploy -pl persistence/binary-jdk17 deploy -Dscan.value.profile="deploy" -Dscan.value.project="binary-jdk17"
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
           PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -63,7 +63,7 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl persistence/binary-jdk17 deploy -Dscan.value.profile="deploy" -Dscan.value.project="binary-jdk17"
+          mvn -Pdeploy -pl persistence/binary-jdk17 clean deploy -Dscan.value.profile="deploy" -Dscan.value.project="binary-jdk17"
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ profile
 
 # Vim
 *.swp
+
+# Develocity
+.mvn/.develocity/develocity-workspace-id

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -33,10 +33,10 @@
   </buildScan>
   <buildCache>
     <local>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
     </local>
     <remote>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
       <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
     </remote>
   </buildCache>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<!--
+ *******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************
+-->
+<develocity
+  xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <server>
+    <url>https://develocity-staging.eclipse.org</url>
+  </server>
+  <projectId>technology.serializer</projectId>
+  <buildScan>
+    <obfuscation>
+      <ipAddresses>0.0.0.0</ipAddresses>
+    </obfuscation>
+    <publishing>
+      <onlyIf>
+        <![CDATA[authenticated]]>
+      </onlyIf>
+    </publishing>
+    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>false</enabled>
+    </local>
+    <remote>
+      <enabled>false</enabled>
+      <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************
+-->
+<extensions>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>develocity-maven-extension</artifactId>
+		<version>1.23</version>
+	</extension>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>common-custom-user-data-maven-extension</artifactId>
+		<version>2.0.1</version>
+	</extension>
+</extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,30 @@
 						<outputDirectory>${project.build.directory}/sbom</outputDirectory>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>com.gradle</groupId>
+					<artifactId>develocity-maven-extension</artifactId>
+					<configuration>
+						<develocity>
+							<normalization>
+								<runtimeClassPath>
+									<metaInf>
+										<ignoredAttributes>
+											<ignore>Bnd-LastModified</ignore>
+											<ignore>Bundle-Version</ignore>
+											<ignore>Created-By</ignore>
+											<ignore>Tool</ignore>
+										</ignoredAttributes>
+									</metaInf>
+									<ignoredFiles>
+										<ignoredFile>META-INF/Eclipse-Serializer-Sbom.json</ignoredFile>
+										<ignoredFile>META-INF/Eclipse-Serializer-Sbom.xml</ignoredFile>
+									</ignoredFiles>
+								</runtimeClassPath>
+							</normalization>
+						</develocity>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
This PR will enable you to publish Build Scans to [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org) as explained in the issue #169. 

## Description
This PR publishes a build scan for every CI build and for every local build from an authenticated Eclipse committer. The build will not fail if publishing fails. This will effectively work as it did before migrating the project from MicrostreamOne, where you already used [Develocity](https://ge.microstream.one/scans?search.relativeStartTime=P90D). As such, I also enabled caching already and applied the configurations from the [microstream](https://github.com/microstream-one/microstream/blob/master/pom.xml#L373-L404) project.

The build scans of the Eclipse Serializer project are published to the Develocity instance at [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), hosted by the Eclipse Foundation and run in partnership between the Eclipse and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Eclipse Serializer project and all other Eclipse projects.

On this Develocity instance, the Eclipse Serializer project will have access not only to all of the published build scans but also to other aggregate data features such as:

* Dashboards to view all historical build scans, along with performance [trends](https://develocity-staging.eclipse.org/scans/trends?search.relativeStartTime=P28D&trends.timeResolution=week) over time
* [Build failure analytics](https://develocity-staging.eclipse.org/scans/failures?search.relativeStartTime=P28D) for enhanced investigation and diagnosis of build failures
* [Test failure analytics](https://develocity-staging.eclipse.org/scans/tests?search.relativeStartTime=P28D) to better understand trends and causes around slow, failing, and flaky tests

This will also enable you to (optionally) use build time optimization features, such as (remote) build caching and Predictive Test Selection. 

As mentioned above, this PR already enabled local and remote caching, which brings `mvn clean install` execution on my local machine from [15.4s](https://ge.solutions-team.gradle.com/s/wwtuf6452ktdc#timeline) (without cache hits) down to [9.4s](https://ge.solutions-team.gradle.com/s/34xlhbrkrsbuk#timeline) (with local cache hits), resulting in ~38% improvement when all goals get a cache hit.

More information can be read in the [Eclipse announcement](https://www.eclipse.org/lists/cross-project-issues-dev/msg20000.html). 

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.

### IMPORTANT
**To get scans publishing on CI, a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket needs to be opened in order for those credentials to be created, as explained in the [initiative documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration).**
