### PR TITLE
Fix possible NPE in LazyReferenceManager.Default.updateStatistics

### DIFF
--- a/base/src/main/java/org/eclipse/serializer/reference/LazyReferenceManager.java
+++ b/base/src/main/java/org/eclipse/serializer/reference/LazyReferenceManager.java
@@ -436,7 +436,8 @@ public interface LazyReferenceManager
 			for(Entry e = this.head; (e = e.nextLazyManagerEntry) != null;)
 			{
 				lazyReferences++;
-				if(e.get().isLoaded())
+				final Lazy<?> ref = e.get();
+				if(ref != null && ref.isLoaded())
 				{
 					loadedLazyReferences++;
 				}


### PR DESCRIPTION
This PR tries to fix the high CPU usage of the LazyReferenceManager caused by a NPE resulting in skipping the sleep.
Reported with #122 and https://github.com/eclipse-store/store/issues/335.

The exact cause of the situation is unknown, but this fixes the high load and improves the robustness of the code at this section.

If this is not an anticipated solution just let me know and deny/delete the PR.

