### PR TITLE
add clean in build

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -25,7 +25,7 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B clean package --file pom.xml
 
       #Build with java 17
     - uses: actions/checkout@v3
@@ -36,4 +36,4 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml      
+      run: mvn -B clean package --file pom.xml

--- a/.github/workflows/maven_build_win.yml
+++ b/.github/workflows/maven_build_win.yml
@@ -25,7 +25,7 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B clean package --file pom.xml
 
       #Build with java 17
     - uses: actions/checkout@v3
@@ -36,4 +36,4 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml      
+      run: mvn -B clean package --file pom.xml

--- a/.github/workflows/maven_deploy_snapshot.yml
+++ b/.github/workflows/maven_deploy_snapshot.yml
@@ -54,7 +54,7 @@ jobs:
           mvn -pl persistence/binary-jdk17 clean install -am -B
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl persistence/binary-jdk17 deploy
+          mvn -Pdeploy -pl persistence/binary-jdk17 clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -98,7 +98,7 @@ jobs:
           mvn -pl persistence/binary-jdk17 clean install -am -B
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl persistence/binary-jdk17 deploy
+          mvn -Pdeploy -pl persistence/binary-jdk17 clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}

--- a/.github/workflows/maven_javadoc.yml
+++ b/.github/workflows/maven_javadoc.yml
@@ -25,7 +25,7 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -P javadoc-check -B package --file pom.xml
+      run: mvn -P clean javadoc-check -B package --file pom.xml
 
       #Build with java 17
     - uses: actions/checkout@v3
@@ -36,4 +36,4 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -P javadoc-check -B package --file pom.xml
+      run: mvn -P clean javadoc-check -B package --file pom.xml

--- a/.github/workflows/maven_javadoc.yml
+++ b/.github/workflows/maven_javadoc.yml
@@ -25,7 +25,7 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -P clean javadoc-check -B package --file pom.xml
+      run: mvn -P javadoc-check -B clean package --file pom.xml
 
       #Build with java 17
     - uses: actions/checkout@v3
@@ -36,4 +36,4 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -P clean javadoc-check -B package --file pom.xml
+      run: mvn -P javadoc-check -B clean package --file pom.xml

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -56,7 +56,7 @@ jobs:
           mvn -pl persistence/binary-jdk17 clean install -am -B
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl persistence/binary-jdk17 deploy
+          mvn -Pdeploy -pl persistence/binary-jdk17 clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}


### PR DESCRIPTION
This pull request includes changes to multiple GitHub Actions workflows to ensure that Maven build commands include the `clean` phase. This helps to ensure that the build starts from a clean slate each time, preventing potential issues from leftover files.

The most important changes include:

### Maven Build Workflows:

* [`.github/workflows/maven_build.yml`](diffhunk://#diff-5e9df5c7ba9a0e12d454053f62cec530d95c52e2dc4a4f1e6755b6499686d764L28-R28): Updated the Maven build command to include the `clean` phase. [[1]](diffhunk://#diff-5e9df5c7ba9a0e12d454053f62cec530d95c52e2dc4a4f1e6755b6499686d764L28-R28) [[2]](diffhunk://#diff-5e9df5c7ba9a0e12d454053f62cec530d95c52e2dc4a4f1e6755b6499686d764L39-R39)
* [`.github/workflows/maven_build_win.yml`](diffhunk://#diff-e77b56b9896f79686ebc79a8aa2f9a3504f3a42badbb6f53e667642a68fa6259L28-R28): Updated the Maven build command to include the `clean` phase. [[1]](diffhunk://#diff-e77b56b9896f79686ebc79a8aa2f9a3504f3a42badbb6f53e667642a68fa6259L28-R28) [[2]](diffhunk://#diff-e77b56b9896f79686ebc79a8aa2f9a3504f3a42badbb6f53e667642a68fa6259L39-R39)

### Maven Deploy Workflows:

* [`.github/workflows/maven_deploy_snapshot.yml`](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L57-R57): Updated the Maven deploy command to include the `clean` phase.
* [`.github/workflows/maven_deploy_snapshot_dev.yml`](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L101-R101): Updated the Maven deploy command to include the `clean` phase.
* [`.github/workflows/maven_release.yml`](diffhunk://#diff-81f8c014d70e0efb7dd886d9353bd9f2d694907253e3abdfa029f9cdb3c9fba1L59-R59): Updated the Maven deploy command to include the `clean` phase.

### Maven Javadoc Workflow:

* [`.github/workflows/maven_javadoc.yml`](diffhunk://#diff-013a2ec5c7db633eb7cfe5ed77d6536fed02843f4d5c253f059e2728751b3e16L28-R28): Updated the Maven Javadoc build command to include the `clean` phase. [[1]](diffhunk://#diff-013a2ec5c7db633eb7cfe5ed77d6536fed02843f4d5c253f059e2728751b3e16L28-R28) [[2]](diffhunk://#diff-013a2ec5c7db633eb7cfe5ed77d6536fed02843f4d5c253f059e2728751b3e16L39-R39)