### PR TITLE
Add production profile to deployment command in maven_release.yml

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -56,7 +56,7 @@ jobs:
           mvn -pl persistence/binary-jdk17 clean install -am -B
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl persistence/binary-jdk17 clean deploy
+          mvn -Pdeploy -Pproduction -pl persistence/binary-jdk17 clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}


### PR DESCRIPTION
This pull request includes a modification to the Maven release workflow configuration file. The change adds a new profile to the deployment command for the Java 17 module.

* [`.github/workflows/maven_release.yml`](diffhunk://#diff-81f8c014d70e0efb7dd886d9353bd9f2d694907253e3abdfa029f9cdb3c9fba1L59-R59): Added the `production` profile to the Maven deploy command for the `persistence/binary-jdk17` module.