### PR TITLE
Refactor Maven release workflow to use updated GPG key and passphrase…

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -12,11 +12,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - id: install-secret-key
-        name: Install gpg secret key
-        run: |
-          cat <(echo -e "${{ secrets.ORG_GPG_PRIVATE_KEY }}") | gpg --batch --import
-          gpg --list-secret-keys --keyid-format LONG
       - uses: actions/checkout@v3
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v3
@@ -27,7 +22,6 @@ jobs:
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-          gpg-passphrase: PASSPHRASE
       - name: Maven change version
         run: mvn versions:set -DnewVersion=${{ github.event.release.tag_name }} --batch-mode
       - name: Make a release
@@ -35,7 +29,8 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
-          PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          MAVEN_GPG_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
 
       #java 17 build
       - uses: actions/checkout@v3
@@ -48,7 +43,6 @@ jobs:
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-          gpg-passphrase: PASSPHRASE
       - name: Maven change version
         run: mvn versions:set -DnewVersion=${{ github.event.release.tag_name }} --batch-mode
       - name: Build with java 17
@@ -60,4 +54,5 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
-          PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          MAVEN_GPG_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}


### PR DESCRIPTION
This pull request includes changes to the Maven release workflow configuration in the `.github/workflows/maven_release.yml` file. The main focus of the changes is to update the handling of GPG keys and passphrases for publishing to the Maven Central Repository.

Changes to GPG key handling:

* Removed the step for installing the GPG secret key directly in the workflow.
* Updated environment variables to use `MAVEN_GPG_PASSPHRASE` and `MAVEN_GPG_KEY` instead of `PASSPHRASE`. [[1]](diffhunk://#diff-81f8c014d70e0efb7dd886d9353bd9f2d694907253e3abdfa029f9cdb3c9fba1L30-R33) [[2]](diffhunk://#diff-81f8c014d70e0efb7dd886d9353bd9f2d694907253e3abdfa029f9cdb3c9fba1L63-R58)

These changes aim to streamline the workflow and improve the security and management of GPG keys during the Maven release process.… environment variables