### PR TITLE
Zj/GitHub action v4 130325

### DIFF
--- a/.github/workflows/maven_deploy_snapshot.yml
+++ b/.github/workflows/maven_deploy_snapshot.yml
@@ -25,7 +25,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Make a snapshot
-        run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy -U
+        run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -32,7 +32,7 @@ jobs:
           newVersion="${currentVersion%-SNAPSHOT}-$SUFFIX-SNAPSHOT"
           mvn versions:set -DnewVersion=$newVersion --batch-mode
       - name: Make a snapshot
-        run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy -U
+        run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows for deploying Maven snapshots. The changes primarily focus on upgrading the actions used and refining the deployment process, especially for Java 17 builds.

### Workflow Updates:

* Updated `actions/checkout` and `actions/setup-java` to version 4 in `.github/workflows/maven_deploy_snapshot.yml` and `.github/workflows/maven_deploy_snapshot_dev.yml`. [[1]](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L17-R19) [[2]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L17-R16)
* Added `-Pproduction` profile to the Maven deploy commands to ensure production settings are used during deployment. [[1]](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L28-R54) [[2]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L70-R71)

### Java 17 Build Process:

* Introduced a separate `publish_java17` job in both workflow files to handle Java 17 builds and deployments. [[1]](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L28-R54) [[2]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L70-R71)
* Simplified the suffix preparation logic for branch names in the `maven_deploy_snapshot_dev.yml` workflow. [[1]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L29-R48) [[2]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L70-R71)

These updates aim to streamline the deployment process and ensure compatibility with the latest versions of the GitHub Actions.