### PR TITLE
Add Javadoc comments for constructors and factory methods in binary h…

### DIFF
--- a/persistence/binary-jdk17/src/main/java/org/eclipse/serializer/persistence/binary/jdk17/java/util/AbstractBinaryHandlerGenericImmutableCollections12.java
+++ b/persistence/binary-jdk17/src/main/java/org/eclipse/serializer/persistence/binary/jdk17/java/util/AbstractBinaryHandlerGenericImmutableCollections12.java
@@ -40,6 +40,11 @@ public abstract class AbstractBinaryHandlerGenericImmutableCollections12<T> exte
 	// abstract methods //
 	/////////////////////
 
+	/**
+	 * Create a new instance of the handled type.
+	 *
+	 * @return the new instance.
+	 */
 	protected abstract T createInstance();
 
 
@@ -64,6 +69,11 @@ public abstract class AbstractBinaryHandlerGenericImmutableCollections12<T> exte
 	// constructors //
 	/////////////////
 
+	/**
+	 * Constructor
+	 *
+	 * @param type the handled type.
+	 */
 	protected AbstractBinaryHandlerGenericImmutableCollections12(final Class<T> type)
 	{
 		super(type,

--- a/persistence/binary-jdk17/src/main/java/org/eclipse/serializer/persistence/binary/jdk17/java/util/BinaryHandlerImmutableCollectionsList12.java
+++ b/persistence/binary-jdk17/src/main/java/org/eclipse/serializer/persistence/binary/jdk17/java/util/BinaryHandlerImmutableCollectionsList12.java
@@ -33,6 +33,11 @@ public class BinaryHandlerImmutableCollectionsList12<T> extends AbstractBinaryHa
 	// static methods //
 	///////////////////
 
+	/**
+	 * Create a new instance of the handler.
+	 *
+	 * @return the new instance.
+	 */
 	public static BinaryHandlerImmutableCollectionsList12<?> New()
 	{
 		return new BinaryHandlerImmutableCollectionsList12<>(List.of(new Object()).getClass());
@@ -43,6 +48,11 @@ public class BinaryHandlerImmutableCollectionsList12<T> extends AbstractBinaryHa
 	// constructors //
 	/////////////////
 
+	/**
+	 * Constructor
+	 *
+	 * @param type the handled type.
+	 */
 	protected BinaryHandlerImmutableCollectionsList12(final Class<T> type)
 	{
 		super(type);

--- a/persistence/binary-jdk17/src/main/java/org/eclipse/serializer/persistence/binary/jdk17/java/util/BinaryHandlerImmutableCollectionsSet12.java
+++ b/persistence/binary-jdk17/src/main/java/org/eclipse/serializer/persistence/binary/jdk17/java/util/BinaryHandlerImmutableCollectionsSet12.java
@@ -33,6 +33,11 @@ public class BinaryHandlerImmutableCollectionsSet12<T> extends AbstractBinaryHan
 	// static methods //
 	///////////////////
 
+	/**
+	 * Create a new instance of the handler.
+	 *
+	 * @return the new instance.
+	 */
 	public static BinaryHandlerImmutableCollectionsSet12<?> New()
 	{
 		return new BinaryHandlerImmutableCollectionsSet12<>(Set.of(new Object()).getClass());
@@ -43,6 +48,11 @@ public class BinaryHandlerImmutableCollectionsSet12<T> extends AbstractBinaryHan
 	// constructors //
 	/////////////////
 
+	/**
+	 * Constructor
+	 *
+	 * @param type the handled type.
+	 */
 	protected BinaryHandlerImmutableCollectionsSet12(final Class<T> type)
 	{
 		super(type);

--- a/persistence/binary-jdk17/src/main/java/org/eclipse/serializer/persistence/binary/jdk17/types/BinaryHandlersJDK17.java
+++ b/persistence/binary-jdk17/src/main/java/org/eclipse/serializer/persistence/binary/jdk17/types/BinaryHandlersJDK17.java
@@ -22,8 +22,18 @@ import org.eclipse.serializer.persistence.binary.types.Binary;
 import org.eclipse.serializer.persistence.types.PersistenceTypeHandlerRegistration;
 import org.eclipse.serializer.util.X;
 
+/**
+ * Utility class for registering all JDK 17 type handlers.
+ */
 public final class BinaryHandlersJDK17
 {
+
+	/**
+	 * Registers all JDK 17 type handlers.
+	 * @param executor the executor to register the type handlers with
+	 * @return the executor
+	 * @param <F> the type of the executor
+	 */
 	public static <F extends PersistenceTypeHandlerRegistration.Executor<Binary>> F registerJDK17TypeHandlers(final F executor)
 	{
 		executor.executeTypeHandlerRegistration((r, c) -> r.registerTypeHandlers(jdk17TypeHandlers()));
@@ -31,7 +41,11 @@ public final class BinaryHandlersJDK17
 		return executor;
 	}
 
-	
+	/**
+	 * Returns a collection of all JDK 17 type handlers.
+	 *
+	 * @return the collection of JDK 17 type handlers.
+	 */
 	public static XGettingCollection<AbstractBinaryHandlerCustom<? extends Object>> jdk17TypeHandlers()
 	{
 		return X.List(


### PR DESCRIPTION
This pull request includes several documentation improvements and the addition of new methods to enhance the functionality of the `persistence/binary-jdk17` module. The most important changes include adding Javadoc comments to constructors and methods, and creating new instances of handlers for collections.

Documentation improvements:

* [`persistence/binary-jdk17/src/main/java/org/eclipse/serializer/persistence/binary/jdk17/java/util/AbstractBinaryHandlerGenericImmutableCollections12.java`](diffhunk://#diff-85960183a913b38ccf61add50986ac966ef315204df0305b4ea9646adf71ea49R43-R47): Added Javadoc comments to the `createInstance` method and the constructor. [[1]](diffhunk://#diff-85960183a913b38ccf61add50986ac966ef315204df0305b4ea9646adf71ea49R43-R47) [[2]](diffhunk://#diff-85960183a913b38ccf61add50986ac966ef315204df0305b4ea9646adf71ea49R72-R76)
* [`persistence/binary-jdk17/src/main/java/org/eclipse/serializer/persistence/binary/jdk17/java/util/BinaryHandlerImmutableCollectionsList12.java`](diffhunk://#diff-b3b7ba4c597fdc47b6639bdfbca4e32ffd6cbb92eb3e86a174543f2a128f856eR36-R40): Added Javadoc comments to the `New` method and the constructor. [[1]](diffhunk://#diff-b3b7ba4c597fdc47b6639bdfbca4e32ffd6cbb92eb3e86a174543f2a128f856eR36-R40) [[2]](diffhunk://#diff-b3b7ba4c597fdc47b6639bdfbca4e32ffd6cbb92eb3e86a174543f2a128f856eR51-R55)
* [`persistence/binary-jdk17/src/main/java/org/eclipse/serializer/persistence/binary/jdk17/java/util/BinaryHandlerImmutableCollectionsSet12.java`](diffhunk://#diff-65e448d2475ee75c62251c89c609ca1910eff57c53e8df6d4bb07624583c8e2eR36-R40): Added Javadoc comments to the `New` method and the constructor. [[1]](diffhunk://#diff-65e448d2475ee75c62251c89c609ca1910eff57c53e8df6d4bb07624583c8e2eR36-R40) [[2]](diffhunk://#diff-65e448d2475ee75c62251c89c609ca1910eff57c53e8df6d4bb07624583c8e2eR51-R55)
* [`persistence/binary-jdk17/src/main/java/org/eclipse/serializer/persistence/binary/jdk17/types/BinaryHandlersJDK17.java`](diffhunk://#diff-82b543a16bcb50595da31911efe9ca1c40f7885173397f08cb137cd2e06ec381R25-R48): Added Javadoc comments to the `registerJDK17TypeHandlers` method and the `jdk17TypeHandlers` method.…andler classes