### PR TITLE
docu: Update serializer dependency version to 2.1.3 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Classes evolve over time. Therefore, Eclipse Serializer provides a legacy type m
 <dependency>
   <groupId>org.eclipse.serializer</groupId>
   <artifactId>serializer</artifactId>
-  <version>2.1.2</version>
+  <version>2.1.3</version>
 </dependency>
 ```
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the version of the `org.eclipse.serializer` dependency from `2.1.2` to `2.1.3`.