### PR TITLE
Update MonitoringManager improved warning in case of JMX monitoring bean registration failure.

### DIFF
--- a/base/src/main/java/org/eclipse/serializer/monitoring/MonitoringManager.java
+++ b/base/src/main/java/org/eclipse/serializer/monitoring/MonitoringManager.java
@@ -206,7 +206,8 @@ public interface MonitoringManager
 				| MalformedObjectNameException e
 			)
 			{
-				logger.warn("Failed to register JMX Bean", e);
+				logger.warn("JMX bean not registered: {}.", metric.getClass());
+				logger.debug("Failed to register JMX bean:", e);
 			}
 		}
 		


### PR DESCRIPTION
Exception is only printed on debug log level.
At warning log level exception is no more added.