### PR TITLE
Update build configurations to use JDK 17 across all workflows and ad…

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -16,23 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      #Build with java 11
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: 'maven'
-    - name: Build with Maven
-      run: mvn -B clean package --file pom.xml
-
-      #Build with java 17
     - uses: actions/checkout@v3
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '11'
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven

--- a/.github/workflows/maven_build_win.yml
+++ b/.github/workflows/maven_build_win.yml
@@ -16,23 +16,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      #Build with java 11
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: 'maven'
-    - name: Build with Maven
-      run: mvn -B clean package --file pom.xml
-
-      #Build with java 17
     - uses: actions/checkout@v3
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '11'
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven

--- a/.github/workflows/maven_deploy_snapshot.yml
+++ b/.github/workflows/maven_deploy_snapshot.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Java for publishing to Maven Central Snapshot Repository
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
           server-id: ossrh
@@ -26,32 +26,6 @@ jobs:
           server-password: MAVEN_PASSWORD
       - name: Make a snapshot
         run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy
-        env:
-          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
-          MAVEN_GPG_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
-
-  publish_java17:
-    if: github.repository == 'eclipse-serializer/serializer'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Java for publishing to Maven Central Snapshot Repository (Java 17)
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-      - name: Build with Java 17
-        run: |
-          mvn -pl persistence/binary-jdk17 clean install -am -B
-      - name: Deploy module build with Java 17
-        run: |
-          mvn -Pdeploy -Pproduction -pl persistence/binary-jdk17 clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Java for publishing to Maven Central Snapshot Repository
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
           server-id: ossrh
@@ -33,42 +33,6 @@ jobs:
           mvn versions:set -DnewVersion=$newVersion --batch-mode
       - name: Make a snapshot
         run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy
-        env:
-          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
-          MAVEN_GPG_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
-
-  publish_java17:
-    if: github.repository == 'eclipse-serializer/serializer'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Java for publishing to Maven Central Snapshot Repository (Java 17)
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-      - name: Prepare suffix
-        run: |
-          suffix=$(echo -n "${GITHUB_REF#refs/heads/}" | tr '/' '_' | cut -c1-10)-$(echo -n "${GITHUB_REF#refs/heads/}" | md5sum | cut -c1-10)
-          echo "Suffix: $suffix"
-          echo "SUFFIX=$suffix" >> $GITHUB_ENV
-      - name: Update project version
-        run: |
-          currentVersion=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-          newVersion="${currentVersion%-SNAPSHOT}-$SUFFIX-SNAPSHOT"
-          mvn versions:set -DnewVersion=$newVersion --batch-mode
-      - name: Build with Java 17
-        run: |
-          mvn -Pproduction -pl persistence/binary-jdk17 clean install -am -B
-      - name: Deploy module build with Java 17
-        run: |
-          mvn -Pdeploy -Pproduction -pl persistence/binary-jdk17 clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}

--- a/.github/workflows/maven_javadoc.yml
+++ b/.github/workflows/maven_javadoc.yml
@@ -16,23 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      #Build with java 11
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: 'maven'
-    - name: Build with Maven
-      run: mvn -P javadoc-check -B clean package --file pom.xml
-
-      #Build with java 17
     - uses: actions/checkout@v3
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '11'
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -80,6 +80,10 @@
 								<id>default-compile</id>
 								<configuration>
 									<compilerArgument>-warn:-serial,-unusedImport</compilerArgument>
+									<compilerArgs>
+										<arg>--release</arg>
+										<arg>11</arg>
+									</compilerArgs>
 								</configuration>
 							</execution>
 						</executions>

--- a/persistence/binary-jdk17/pom.xml
+++ b/persistence/binary-jdk17/pom.xml
@@ -18,8 +18,7 @@
 	<url>https://projects.eclipse.org/projects/technology.serializer</url>
 	
 	<properties>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<java.release>17</java.release>
 	</properties>
 	
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.compilerId>javac</maven.compiler.compilerId>
+		<java.release>11</java.release>
 		<maven.version.minimum>3.8.1</maven.version.minimum>
 		<maven.java.version.minimum>11</maven.java.version.minimum>
 		<org.eclipse.jdt.ecj.version>3.33.0</org.eclipse.jdt.ecj.version>
@@ -125,6 +124,9 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.13.0</version>
+					<configuration>
+						<release>${java.release}</release>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
One step build, with java 17, use release tag to provide output artefacts compatible with java 11.


### Workflow Updates:

* [`.github/workflows/maven_build.yml`](diffhunk://#diff-5e9df5c7ba9a0e12d454053f62cec530d95c52e2dc4a4f1e6755b6499686d764L19-R23): Removed the separate build steps for Java 11 and Java 17, and updated the remaining build to use Java 11.
* [`.github/workflows/maven_build_win.yml`](diffhunk://#diff-e77b56b9896f79686ebc79a8aa2f9a3504f3a42badbb6f53e667642a68fa6259L19-R23): Similarly, consolidated builds into a single step using Java 11.
* [`.github/workflows/maven_deploy_snapshot.yml`](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L21-R21): Updated the Java version for snapshot deployment from Java 11 to Java 17 and removed the redundant `publish_java17` job. [[1]](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L21-R21) [[2]](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L35-L60)
* [`.github/workflows/maven_deploy_snapshot_dev.yml`](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L18-R18): Changed the Java version for snapshot deployment from Java 11 to Java 17 and eliminated the `publish_java17` job. [[1]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L18-R18) [[2]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L41-L76)
* [`.github/workflows/maven_javadoc.yml`](diffhunk://#diff-013a2ec5c7db633eb7cfe5ed77d6536fed02843f4d5c253f059e2728751b3e16L19-R23): Consolidated Javadoc builds into a single step using Java 11.

### Build Configuration Enhancements:

* [`base/pom.xml`](diffhunk://#diff-7dbac9afd5999b020baaf066bac70ea6fec4c301459419d42fbe34ea7f1c8cf6R83-R86): Added `--release 11` argument to the compiler configuration for better compatibility with Java 11.
* [`persistence/binary-jdk17/pom.xml`](diffhunk://#diff-14f34136fb7f025dc3395d40d879f98293593b82b2ff174226140045d9ebf27cL21-R21): Replaced `maven.compiler.source` and `maven.compiler.target` with `java.release` for Java 17.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L39-R40): Updated Java version management by replacing `maven.compiler.source` and `maven.compiler.target` with `java.release` for Java 11, and added a `release` configuration to the `maven-compiler-plugin`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L39-R40) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R127-R129)