### PR TITLE
refactor: update Maven compiler properties for Java versioning

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -80,10 +80,6 @@
 								<id>default-compile</id>
 								<configuration>
 									<compilerArgument>-warn:-serial,-unusedImport</compilerArgument>
-									<compilerArgs>
-										<arg>--release</arg>
-										<arg>11</arg>
-									</compilerArgs>
 								</configuration>
 							</execution>
 						</executions>

--- a/persistence/binary-jdk17/pom.xml
+++ b/persistence/binary-jdk17/pom.xml
@@ -18,7 +18,7 @@
 	<url>https://projects.eclipse.org/projects/technology.serializer</url>
 	
 	<properties>
-		<java.release>17</java.release>
+		<maven.compiler.release>17</maven.compiler.release>
 	</properties>
 	
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.compilerId>javac</maven.compiler.compilerId>
-		<java.release>11</java.release>
+		<maven.compiler.release>11</maven.compiler.release>
 		<maven.version.minimum>3.8.1</maven.version.minimum>
 		<maven.java.version.minimum>11</maven.java.version.minimum>
 		<org.eclipse.jdt.ecj.version>3.33.0</org.eclipse.jdt.ecj.version>
@@ -124,9 +124,6 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.13.0</version>
-					<configuration>
-						<release>${java.release}</release>
-					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This pull request updates Maven build configurations across several `pom.xml` files to standardize the use of the `maven.compiler.release` property and remove deprecated or redundant configurations. These changes improve maintainability and align the project with modern Maven practices.

### Standardization of Maven compiler properties:

* [`persistence/binary-jdk17/pom.xml`](diffhunk://#diff-14f34136fb7f025dc3395d40d879f98293593b82b2ff174226140045d9ebf27cL21-R21): Replaced the `java.release` property with `maven.compiler.release` to specify the Java release version. (`[persistence/binary-jdk17/pom.xmlL21-R21](diffhunk://#diff-14f34136fb7f025dc3395d40d879f98293593b82b2ff174226140045d9ebf27cL21-R21)`)
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L40-R40): Updated the `java.release` property to `maven.compiler.release` for consistency and removed redundant `<release>` configuration from the `maven-compiler-plugin`. (`[[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L40-R40)`, `[[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L127-L129)`)

### Removal of redundant Maven configurations:

* [`base/pom.xml`](diffhunk://#diff-7dbac9afd5999b020baaf066bac70ea6fec4c301459419d42fbe34ea7f1c8cf6L83-L86): Removed `<compilerArgs>` specifying `--release 11`, as this is now handled by the standardized `maven.compiler.release` property. (`[base/pom.xmlL83-L86](diffhunk://#diff-7dbac9afd5999b020baaf066bac70ea6fec4c301459419d42fbe34ea7f1c8cf6L83-L86)`)