### PR TITLE
Zj/missing licence header check 280725

### DIFF
--- a/.github/workflows/maven_licence_check.yml
+++ b/.github/workflows/maven_licence_check.yml
@@ -1,0 +1,28 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Licence header check
+
+on:
+  push:
+    branches: 
+      - '**'
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      #Build with java 17
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: 'maven'
+    - name: Build with Maven
+      run: mvn -B clean license:check-file-header --file pom.xml

--- a/afs/afs/src/main/java/org/eclipse/serializer/afs/exceptions/AfsException.java
+++ b/afs/afs/src/main/java/org/eclipse/serializer/afs/exceptions/AfsException.java
@@ -1,6 +1,18 @@
 package org.eclipse.serializer.afs.exceptions;
 
-
+/*-
+ * #%L
+ * Eclipse Serializer Abstract File System
+ * %%
+ * Copyright (C) 2023 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
 
 import org.eclipse.serializer.exceptions.BaseException;
 

--- a/afs/afs/src/main/java/org/eclipse/serializer/afs/exceptions/AfsException.java
+++ b/afs/afs/src/main/java/org/eclipse/serializer/afs/exceptions/AfsException.java
@@ -1,18 +1,6 @@
 package org.eclipse.serializer.afs.exceptions;
 
-/*-
- * #%L
- * Eclipse Serializer Abstract File System
- * %%
- * Copyright (C) 2023 MicroStream Software
- * %%
- * This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License 2.0
- * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
- * #L%
- */
+
 
 import org.eclipse.serializer.exceptions.BaseException;
 

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,7 @@
 							<include>**/*.java</include>
 						</includes>
 						<ignoreNoFileToScan>true</ignoreNoFileToScan>
+						<failOnMissingHeader>true</failOnMissingHeader>
 					</configuration>
 					<executions>
 						<execution>


### PR DESCRIPTION
Check: build - failed, if any licence header is missing. 