### PR TITLE
chore: add GitHub Actions workflow for generating Maven SBOM

### DIFF
--- a/.github/workflows/generate-maven-sbom.yml
+++ b/.github/workflows/generate-maven-sbom.yml
@@ -45,6 +45,9 @@ jobs:
 
       - name: Generate
         run: |
+          if git show-ref --tags --quiet --verify "refs/tags/${PROJECT_VERSION}"; then
+            mvn versions:set -DnewVersion=${PROJECT_VERSION} --batch-mode
+          fi
           # Generate SBOMs. 'skipNotDeployed' is needed
           # to generate an SBOM outside of the deployment phase.
 

--- a/.github/workflows/generate-maven-sbom.yml
+++ b/.github/workflows/generate-maven-sbom.yml
@@ -1,0 +1,71 @@
+name: Generate Maven SBOM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    # Provide custom 'Version' input, to allow running the workflow for older
+    # git refs, where the workflow file did not exist yet. This is not possible
+    # with the builtin "Use workflow from" input field.
+    inputs:
+      version:
+        description: "Version"
+        default: "main"
+        required: true
+
+env:
+  JAVA_VERSION: '17'
+  JAVA_DISTRO: 'temurin'
+  PLUGIN_VERSION: '2.9.1'
+  SBOM_TYPE: 'makeAggregateBom'
+  PROJECT_VERSION: "${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.version }}"
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    outputs:
+      # Make env var available in re-usuable workflow (see actions/runner#2372)
+      project-version: ${{ env.PROJECT_VERSION }}
+    steps:
+      - name: Checkout repository at '${{ env.PROJECT_VERSION }}'
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ env.PROJECT_VERSION }}
+          persist-credentials: false
+
+      - name: Setup Java SDK
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+
+      - name: Generate
+        run: |
+          # Generate SBOMs. 'skipNotDeployed' is needed
+          # to generate an SBOM outside of the deployment phase.
+
+          mvn org.cyclonedx:cyclonedx-maven-plugin:${PLUGIN_VERSION}:${SBOM_TYPE} \
+              -Dcyclonedx.skipNotDeployed=false \
+              -DoutputName=Eclipse-Serializer-Sbom \
+              -DoutputDirectory=target/sbom
+
+      - name: Upload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom
+          path: target/sbom/Eclipse-Serializer-Sbom.json
+
+  # Store SBOM and metadata in a predefined format for otterdog to pick up
+  store-sbom-data:
+    needs: ['generate-sbom']
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: 'serializer'
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: 'sbom'
+      bomFilename: 'Eclipse-Serializer-Sbom.json'
+      parentProject: '8fe715dc-b201-45e0-b6e0-5eb8da2ff4cf'

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If you want to contribute to this project, please read our [guidelines](CONTRIBU
 ## SBOM
 
 To enhance supply chain security and offer users clear insight into project
-components, Eclipse Store now generates a Software Bill of Materials (SBOM) for
+components, Eclipse Serializer now generates a Software Bill of Materials (SBOM) for
 every release. These are published to the Eclipse Foundation SBOM registry,
 with access instructions and usage details available in this [documentation]
 (https://eclipse-csi.github.io/security-handbook/sbom/registry.html).

--- a/README.md
+++ b/README.md
@@ -83,3 +83,11 @@ If you want to contribute to this project, please read our [guidelines](CONTRIBU
 
 - [Eclipse project page](https://projects.eclipse.org/projects/technology.serializer)
 - [Dev mailing list](https://accounts.eclipse.org/mailing-list/serializer-dev)
+
+## SBOM
+
+To enhance supply chain security and offer users clear insight into project
+components, Eclipse Store now generates a Software Bill of Materials (SBOM) for
+every release. These are published to the Eclipse Foundation SBOM registry,
+with access instructions and usage details available in this [documentation]
+(https://eclipse-csi.github.io/security-handbook/sbom/registry.html).

--- a/pom.xml
+++ b/pom.xml
@@ -310,34 +310,6 @@
 					<version>3.6.0</version>
 				</plugin>
 				<plugin>
-					<groupId>org.cyclonedx</groupId>
-					<artifactId>cyclonedx-maven-plugin</artifactId>
-					<version>2.8.1</version>
-					<executions>
-						<execution>
-							<phase>prepare-package</phase>
-							<goals>
-								<goal>makeAggregateBom</goal>
-							</goals>
-						</execution>
-					</executions>
-					<configuration>
-						<projectType>library</projectType>
-						<schemaVersion>1.4</schemaVersion>
-						<includeBomSerialNumber>true</includeBomSerialNumber>
-						<includeCompileScope>true</includeCompileScope>
-						<includeProvidedScope>true</includeProvidedScope>
-						<includeRuntimeScope>true</includeRuntimeScope>
-						<includeSystemScope>true</includeSystemScope>
-						<includeTestScope>false</includeTestScope>
-						<includeLicenseText>false</includeLicenseText>
-						<outputReactorProjects>true</outputReactorProjects>
-						<outputFormat>all</outputFormat>
-						<outputName>Eclipse-Serializer-Sbom</outputName>
-						<outputDirectory>${project.build.directory}/sbom</outputDirectory>
-					</configuration>
-				</plugin>
-				<plugin>
 					<groupId>org.sonatype.central</groupId>
 					<artifactId>central-publishing-maven-plugin</artifactId>
 					<version>0.8.0</version>
@@ -351,42 +323,6 @@
 	</build>
 
 	<profiles>
-		<profile>
-			<id>production</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.cyclonedx</groupId>
-						<artifactId>cyclonedx-maven-plugin</artifactId>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-resources-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>copy-meta-inf-resources</id>
-								<phase>prepare-package</phase>
-								<goals>
-									<goal>copy-resources</goal>
-								</goals>
-								<configuration>
-									<outputDirectory>${project.build.outputDirectory}/META-INF</outputDirectory>
-									<resources>
-										<resource>
-											<directory>${project.build.directory}/sbom/</directory>
-											<includes>
-												<include>*.json</include>
-												<include>*.xml</include>
-											</includes>
-										</resource>
-									</resources>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 		<profile>
 			<id>deploy</id>
 			<build>


### PR DESCRIPTION
This pull request adds a new workflow for generating a Software Bill of Materials (SBOM) for Maven projects using GitHub Actions. The workflow is triggered on releases and manual dispatches, checks out the appropriate version of the repository, sets up Java, runs the CycloneDX Maven plugin to generate the SBOM, uploads the resulting artifact, and then stores the SBOM and metadata for further use.

New GitHub Actions workflow for Maven SBOM generation:

* Added `.github/workflows/generate-maven-sbom.yml` to automate SBOM creation, upload, and metadata storage for Maven projects using CycloneDX.
* Workflow triggers on release publication and manual dispatch, with the option to specify a custom version input for flexibility.
* Uses Java 17 and the CycloneDX Maven plugin to generate an aggregate SBOM, storing the result as an artifact.
* Integrates with a reusable workflow to store SBOM data and metadata in a standardized format for downstream consumption.