### PR TITLE
Add `containsLiveObject` method to object registries

### DIFF
--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/DefaultObjectRegistry.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/DefaultObjectRegistry.java
@@ -422,7 +422,16 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 		}
 	}
 
-	private boolean synchContainsObjectId(final long objectId)
+    @Override
+    public boolean containsLiveObject(final long objectId)
+    {
+        synchronized(this.mutex)
+        {
+            return this.synchContainsLiveObject(objectId);
+        }
+    }
+
+    private boolean synchContainsObjectId(final long objectId)
 	{
 		for(Entry e = this.oidHashTable[(int)objectId & this.hashRange]; e != null; e = e.oidNext)
 		{
@@ -434,6 +443,19 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 		
 		return false;
 	}
+
+    private boolean synchContainsLiveObject(final long objectId)
+    {
+        for(Entry e = this.oidHashTable[(int)objectId & this.hashRange]; e != null; e = e.oidNext)
+        {
+            if(e.objectId == objectId)
+            {
+                return e.get() != null;
+            }
+        }
+
+        return false;
+    }
 	
 	@Override
 	public final long lookupObjectId(final Object object)

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectRegistry.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectRegistry.java
@@ -53,6 +53,8 @@ public interface PersistenceObjectRegistry extends PersistenceSwizzlingLookup, C
 
 	public boolean containsObjectId(long objectId);
 
+    public boolean containsLiveObject(long objectId);
+
 	public <A extends PersistenceAcceptor> A iterateEntries(A acceptor);
 
 	// general querying //


### PR DESCRIPTION
### Description

This pull request introduces the `containsLiveObject` method to object registries, enabling users to check if a specific live object exists within a given registry.

