### PR TITLE
Add containsClearedObject method to ObjectRegistry

### DIFF
--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/DefaultObjectRegistry.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/DefaultObjectRegistry.java
@@ -431,6 +431,15 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
         }
     }
 
+    @Override
+    public boolean containsClearedObject(final long objectId)
+    {
+        synchronized(this.mutex)
+        {
+            return this.synchContainsClearedObject(objectId);
+        }
+    }
+
     private boolean synchContainsObjectId(final long objectId)
 	{
 		for(Entry e = this.oidHashTable[(int)objectId & this.hashRange]; e != null; e = e.oidNext)
@@ -451,6 +460,19 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
             if(e.objectId == objectId)
             {
                 return e.get() != null;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean synchContainsClearedObject(final long objectId)
+    {
+        for(Entry e = this.oidHashTable[(int)objectId & this.hashRange]; e != null; e = e.oidNext)
+        {
+            if(e.objectId == objectId)
+            {
+                return e.get() == null;
             }
         }
 

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectRegistry.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectRegistry.java
@@ -55,6 +55,8 @@ public interface PersistenceObjectRegistry extends PersistenceSwizzlingLookup, C
 
     public boolean containsLiveObject(long objectId);
 
+    public boolean containsClearedObject(long objectId);
+
 	public <A extends PersistenceAcceptor> A iterateEntries(A acceptor);
 
 	// general querying //


### PR DESCRIPTION

This pull request introduces a new method, `containsClearedObject`, to the `ObjectRegistry` class. The method checks if a cleared object is present in the registry.
