### PR TITLE
chore: remove outdated SLF4J dependency from pom.xml

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -23,8 +23,6 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.36</version>
-			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This pull request makes a small change to the project dependencies in `base/pom.xml` by removing the explicit version and scope for the `slf4j-api` dependency.