### PR TITLE
Fix incorrect loop condition in Persistence iterator

### DIFF
--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/Persistence.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/Persistence.java
@@ -511,7 +511,7 @@ public class Persistence
 	)
 	{
 		final int bound = offset + length;
-		for(int i = offset; offset < bound; i++)
+		for(int i = offset; i < bound; i++)
 		{
 			iterator.apply(array[i]);
 		}


### PR DESCRIPTION

This pull request addresses an issue where the loop condition in the `Persistence` iterator was not functioning correctly. The fix ensures the iterator behaves as intended.

