### PR TITLE
fix: implement getPersistedEnumOrdinal in BinaryLegacyTypeHandlerGenericEnum

### DIFF
--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryLegacyTypeHandlerGenericEnum.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryLegacyTypeHandlerGenericEnum.java
@@ -104,5 +104,10 @@ extends AbstractBinaryLegacyTypeHandlerReflective<T>
 		// debug hook
 		super.updateState(rawData, instance, handler);
 	}
-
+	
+	@Override
+	public int getPersistedEnumOrdinal(final Binary data)
+	{
+		return data.read_int(this.binaryOffsetOrdinal);			
+	}
 }


### PR DESCRIPTION
The error was caused by the enums legacy type handler using the new binary offset to load the old, persisted ordinal