### PR TITLE
chore: remove deploy job from pull request configuration in maven_dep…

### DIFF
--- a/.github/workflows/maven_deploy_snapshot.yml
+++ b/.github/workflows/maven_deploy_snapshot.yml
@@ -8,8 +8,6 @@ on:
     branches:
       - main
       - 'release/**'
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build-native:


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration, removing the trigger for running the workflow on pull requests to the `main` branch. The workflow will now only run on pushes to `main` and `release/**` branches.…loy_snapshot.yml