### PR TITLE
chore: update serializer version to 4.0.1 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Classes evolve over time. Therefore, Eclipse Serializer provides a legacy type m
 <dependency>
   <groupId>org.eclipse.serializer</groupId>
   <artifactId>serializer</artifactId>
-  <version>4.0.0</version>
+  <version>4.0.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
This pull request updates the documentation to reference the latest version of the Eclipse Serializer library.

- Documentation update:
  * Updated the Maven dependency version for `org.eclipse.serializer:serializer` from `4.0.0` to `4.0.1` in the `README.md` file.