### PR TITLE
Add OffHeapLongHashSet and utility methods for enhancements

### DIFF
--- a/base/src/main/java/org/eclipse/serializer/chars/VarString.java
+++ b/base/src/main/java/org/eclipse/serializer/chars/VarString.java
@@ -810,6 +810,7 @@ public final class VarString implements CharSequence, Appendable, Serializable
 		return this;
 	}
 
+	@Override
 	public final boolean isEmpty()
 	{
 		return this.size == 0;
@@ -1327,6 +1328,22 @@ public final class VarString implements CharSequence, Appendable, Serializable
 	public final boolean endsWith(final String string)
 	{
 		return this.endsWith(XChars.readChars(string));
+	}
+
+	public final VarString padLeft(final int i, final int totalLength, final char paddingChar)
+	{
+		return this.repeat(calculatePaddingCount(i, totalLength), paddingChar).add(i);
+	}
+
+	private static int calculatePaddingCount(final int i, final int totalLength)
+	{
+		if(i == 0)
+		{
+			return totalLength - 1;
+		}
+
+		final int iLength = XMath.log10discrete(Math.abs(i)) + (i < 0 ? 2 : 1);
+		return max(totalLength - iLength, 0);
 	}
 
 	private static int calculatePaddingCount(final String s, final int totalLength)

--- a/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
+++ b/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
@@ -40,20 +40,21 @@ import java.nio.ByteBuffer;
 public final class OffHeapLongHashSet
 {
 	/* TODO: OffHeapLongHashSet memory segmentation
-	 * Currently, this implementation can theoretically grow infinitely (as long as there is free disk space...),
-	 * but it has one problem:
-	 * It needs to allocate larger and larger monolithic memory blocks, eventually exceeding the memory size.
+	 * Currently, this implementation can theoretically grow very large (as long as enough
+	 * native memory is available), but it has one problem:
+	 * It needs to allocate larger and larger monolithic memory blocks, eventually exceeding
+	 * the available native memory.
 	 * A solution would be:
-	 * - Switch from open adressing to chaining.
+	 * - Switch from open addressing to chaining.
 	 * - Chains are held in another allocated memory block. e.g. always 1024 chains per block (configurable).
 	 * - Multiple chain blocks are allocated as needed, as long as the configuration does not require a storage enlargement.
-	 * - Each chain has a pointer at is end, pointing to the next chain, if necessary.
+	 * - Each chain has a pointer at its end, pointing to the next chain, if necessary.
 	 *   This is important to not force a storage enlargement just because a single chain is full.
 	 *
 	 * This way, the set can be configured to have a maximum hash table length of a certain size (e.g. 1 GB)
 	 * and from then on grow only by having larger and larger chains.
 	 * This creates multiple memory segments that can be allocated and swapped step by step
-	 * without the need to allocate one gigantic block that exceeds the hardware's memory.
+	 * without the need to allocate one gigantic block that exceeds the available native memory.
 	 *
 	 * The tradeoff between hash table size and chain length can be perfectly configured
 	 * using a few simple int values. (maximum hash table length, chain length, chains per block, etc.)

--- a/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
+++ b/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
@@ -170,6 +170,16 @@ public final class OffHeapLongHashSet implements AutoCloseable
 			capacity <<= 1;
 		}
 
+		// The rounded-up power of two may exceed MAX_CAPACITY even when desiredCapacity didn't
+		// (e.g. desiredCapacity == MAX_CAPACITY is not itself a power of two).
+		if(capacity > MAX_CAPACITY)
+		{
+			throw new IllegalArgumentException(
+				"Desired capacity " + desiredCapacity + " rounds up to " + capacity
+				+ " which exceeds the maximum of " + MAX_CAPACITY + "."
+			);
+		}
+
 		return capacity;
 	}
 
@@ -323,8 +333,12 @@ public final class OffHeapLongHashSet implements AutoCloseable
 			return this.containsZero;
 		}
 
-		int collisions = 0;
-		for(long i = this.hash(value); collisions < this.collisionLimit; i = this.advanceIndex(i))
+		// Probe until an EMPTY slot is found. insertBlind() (used during resize) places elements
+		// without enforcing collision limits, so a value may sit further from its hash position
+		// than collisionLimit. Bounding the lookup by collisionLimit would falsely miss it.
+		// The capacity guard ensures termination even if the table is unexpectedly full.
+		final long cap = this.capacity;
+		for(long i = this.hash(value), probes = 0; probes < cap; i = this.advanceIndex(i), probes++)
 		{
 			final long slotValue = this.getValue(i);
 			if(slotValue == EMPTY)
@@ -335,7 +349,6 @@ public final class OffHeapLongHashSet implements AutoCloseable
 			{
 				return true;
 			}
-			collisions++;
 		}
 		return false;
 	}

--- a/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
+++ b/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
@@ -1,5 +1,19 @@
 package org.eclipse.serializer.collections;
 
+/*-
+ * #%L
+ * Eclipse Serializer Base
+ * %%
+ * Copyright (C) 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import org.eclipse.serializer.math.XMath;
 import org.eclipse.serializer.memory.XMemory;
 

--- a/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
+++ b/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
@@ -72,6 +72,13 @@ public final class OffHeapLongHashSet implements AutoCloseable
 
 	private static final long EMPTY = 0L;
 
+	/**
+	 * The maximum capacity in number of {@code long} slots. Constrained by the underlying
+	 * {@link ByteBuffer} which is int-addressed, so the byte size must not exceed
+	 * {@link Integer#MAX_VALUE}.
+	 */
+	private static final long MAX_CAPACITY = Integer.MAX_VALUE / Long.BYTES;
+
 
 
 	///////////////////////////////////////////////////////////////////////////
@@ -149,6 +156,13 @@ public final class OffHeapLongHashSet implements AutoCloseable
 	public static long padCapacity(final long desiredCapacity)
 	{
 		XMath.positive(desiredCapacity);
+
+		if(desiredCapacity > MAX_CAPACITY)
+		{
+			throw new IllegalArgumentException(
+				"Desired capacity " + desiredCapacity + " exceeds the maximum of " + MAX_CAPACITY + "."
+			);
+		}
 
 		long capacity = 1;
 		while(capacity < desiredCapacity)
@@ -286,14 +300,24 @@ public final class OffHeapLongHashSet implements AutoCloseable
 	// methods //
 	////////////
 
+	private void ensureOpen()
+	{
+		if(this.dbb == null)
+		{
+			throw new IllegalStateException("OffHeapLongHashSet has been closed.");
+		}
+	}
+
 	/**
 	 * Returns whether this set contains the given value.
 	 *
 	 * @param value the value to look up.
 	 * @return {@code true} if the value is contained, {@code false} otherwise.
+	 * @throws IllegalStateException if this set has been {@linkplain #close() closed}.
 	 */
 	public boolean contains(final long value)
 	{
+		this.ensureOpen();
 		if(value == EMPTY)
 		{
 			return this.containsZero;
@@ -324,6 +348,7 @@ public final class OffHeapLongHashSet implements AutoCloseable
 	 */
 	public boolean containsAll(final long... values)
 	{
+		this.ensureOpen();
 		for(final long value : values)
 		{
 			if(!this.contains(value))
@@ -342,6 +367,7 @@ public final class OffHeapLongHashSet implements AutoCloseable
 	 */
 	public int putAll(final long... values)
 	{
+		this.ensureOpen();
 		int insertCount = 0;
 		for(final long value : values)
 		{
@@ -363,6 +389,7 @@ public final class OffHeapLongHashSet implements AutoCloseable
 	 */
 	public boolean put(final long value)
 	{
+		this.ensureOpen();
 		if(value == EMPTY)
 		{
 			return this.ensureInsertedZero();
@@ -440,16 +467,22 @@ public final class OffHeapLongHashSet implements AutoCloseable
 	 */
 	private boolean checkForRebuild(final int collisions)
 	{
-		if(collisions < this.collisionThreshold)
+		if(collisions >= this.collisionLimit)
 		{
-			return false; // Acceptable number of collisions.
-		}
-
-		if(collisions >= this.collisionLimit || ++this.excessCount >= this.excessLimit)
-		{
-			this.enlarge(); // Unacceptable number of collisions, enlarge storage.
+			this.enlarge(); // Hard limit reached, enlarge immediately.
 			return true;
 		}
+
+		// Increment excessCount exactly once per insertion — at the moment collisions
+		// first reach the threshold — so that excessCount reflects the number of
+		// insertions that exceeded the acceptable collision count, not the number of
+		// excess probe steps.
+		if(collisions == this.collisionThreshold && ++this.excessCount >= this.excessLimit)
+		{
+			this.enlarge(); // Too many insertions exceeded the collision threshold.
+			return true;
+		}
+
 		return false;
 	}
 
@@ -492,13 +525,26 @@ public final class OffHeapLongHashSet implements AutoCloseable
 
 	private void enlarge()
 	{
-		this.resize(this.capacity << 1);
+		final long doubled = this.capacity << 1;
+		if(doubled > MAX_CAPACITY)
+		{
+			throw new CapacityExceededException(
+				"Cannot enlarge beyond maximum capacity of " + MAX_CAPACITY + " long slots."
+			);
+		}
+		this.resize(doubled);
 	}
 
 	private void resize(final long newCapacity)
 	{
 		// DirectByteBuffer allocation
 		final long newByteCapacity = to_longByteSize(newCapacity);
+		if(newByteCapacity < 0 || newByteCapacity > Integer.MAX_VALUE)
+		{
+			throw new CapacityExceededException(
+				"Required byte capacity " + newByteCapacity + " exceeds the DirectByteBuffer int limit."
+			);
+		}
 		final ByteBuffer newDbb = XMemory.allocateDirectNative(newByteCapacity);
 		final long newBaseAddress = XMemory.getDirectByteBufferAddress(newDbb);
 		XMemory.clearMemory(newBaseAddress, newByteCapacity);
@@ -582,9 +628,9 @@ public final class OffHeapLongHashSet implements AutoCloseable
 	}
 
 	/**
-	 * Releases the off-heap memory backing this set. After this call the set must not be
-	 * used anymore; further calls to {@link #put(long)}, {@link #contains(long)}, etc. will
-	 * produce undefined results. Calling {@code close()} more than once is a no-op.
+	 * Releases the off-heap memory backing this set. After this call, further calls to
+	 * {@link #put(long)}, {@link #contains(long)}, etc. will throw {@link IllegalStateException}.
+	 * Calling {@code close()} more than once is a no-op.
 	 */
 	@Override
 	public void close()

--- a/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
+++ b/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
@@ -615,6 +615,7 @@ public final class OffHeapLongHashSet implements AutoCloseable
 	 */
 	public long size()
 	{
+		this.ensureOpen();
 		return this.size;
 	}
 
@@ -623,9 +624,11 @@ public final class OffHeapLongHashSet implements AutoCloseable
 	 * The capacity is always a power of two and grows only via storage enlargement.
 	 *
 	 * @return the current capacity.
+	 * @throws IllegalStateException if this set has been {@linkplain #close() closed}.
 	 */
 	public long capacity()
 	{
+		this.ensureOpen();
 		return this.capacity;
 	}
 
@@ -634,9 +637,11 @@ public final class OffHeapLongHashSet implements AutoCloseable
 	 * to {@linkplain #capacity() capacity}.
 	 *
 	 * @return a value in {@code [0.0, 1.0]}, or {@code 0.0} if the capacity is zero.
+	 * @throws IllegalStateException if this set has been {@linkplain #close() closed}.
 	 */
 	public double currentLoad()
 	{
+		this.ensureOpen();
 		return this.capacity == 0 ? 0.0 : (double)this.size / this.capacity;
 	}
 

--- a/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
+++ b/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
@@ -371,20 +371,29 @@ public final class OffHeapLongHashSet
 		 * here is irrelevant anyway.
 		 */
 
-		int collisions = 0;
-		for(long i = this.hash(value); true; i = this.advanceIndex(i))
+		// Outer loop: if a resize occurs during probing, the probe must restart with the new
+		// hash range and a fresh collision count, otherwise the value could land in a slot
+		// that is unreachable from hash(value) in the resized table (breaking future contains).
+		while(true)
 		{
-			final long slotValue = this.getValue(i);
-			if(slotValue == EMPTY)
+			int collisions = 0;
+			for(long i = this.hash(value); true; i = this.advanceIndex(i))
 			{
-				this.insertAt(i, value); // empty slot found, insert and return.
-				return true;
+				final long slotValue = this.getValue(i);
+				if(slotValue == EMPTY)
+				{
+					this.insertAt(i, value); // empty slot found, insert and return.
+					return true;
+				}
+				if(slotValue == value)
+				{
+					return false; // value already contained
+				}
+				if(this.checkForRebuild(++collisions))
+				{
+					break; // resize happened; restart probing from hash(value) for the new table.
+				}
 			}
-			if(slotValue == value)
-			{
-				return false; // value already contained
-			}
-			this.checkForRebuild(++collisions); // check for rebuild before trying again.
 		}
 	}
 
@@ -419,17 +428,23 @@ public final class OffHeapLongHashSet
 		return i << 3;
 	}
 
-	private void checkForRebuild(final int collisions)
+	/**
+	 * @return {@code true} if a resize was performed (caller must restart probing with a fresh hash),
+	 *         {@code false} otherwise.
+	 */
+	private boolean checkForRebuild(final int collisions)
 	{
 		if(collisions < this.collisionThreshold)
 		{
-			return; // Acceptable number of collisions.
+			return false; // Acceptable number of collisions.
 		}
 
 		if(collisions >= this.collisionLimit || ++this.excessCount >= this.excessLimit)
 		{
 			this.enlarge(); // Unacceptable number of collisions, enlarge storage.
+			return true;
 		}
+		return false;
 	}
 
 	private boolean ensureInsertedZero()

--- a/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
+++ b/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
@@ -1,0 +1,549 @@
+package org.eclipse.serializer.collections;
+
+import org.eclipse.serializer.math.XMath;
+import org.eclipse.serializer.memory.XMemory;
+
+import java.nio.ByteBuffer;
+
+/**
+ * A hash set for primitive {@code long} values whose backing storage is allocated off-heap
+ * via a direct {@link ByteBuffer}.
+ * <p>
+ * This implementation uses open addressing with linear probing. It is designed for the use case
+ * of collecting a large number of {@code long} values and testing them for presence; it does
+ * <i>not</i> support removal of elements. The value {@code 0L} is supported and tracked separately,
+ * since {@code 0L} is also used internally as the sentinel for empty slots.
+ * <p>
+ * When the number of collisions during an insertion exceeds the configured thresholds,
+ * the backing storage is doubled and all contained values are rehashed into the new storage.
+ * The previous direct buffer is deallocated explicitly in order to release large off-heap
+ * memory chunks immediately instead of waiting for garbage collection.
+ * <p>
+ * Instances are not safe for concurrent modification by multiple threads.
+ *
+ * @see XMemory
+ */
+public final class OffHeapLongHashSet
+{
+	/* TODO: OffHeapLongHashSet memory segmentation
+	 * Currently, this implementation can theoretically grow infinitely (as long as there is free disk space...),
+	 * but it has one problem:
+	 * It needs to allocate larger and larger monolithic memory blocks, eventually exceeding the memory size.
+	 * A solution would be:
+	 * - Switch from open adressing to chaining.
+	 * - Chains are held in another allocated memory block. e.g. always 1024 chains per block (configurable).
+	 * - Multiple chain blocks are allocated as needed, as long as the configuration does not require a storage enlargement.
+	 * - Each chain has a pointer at is end, pointing to the next chain, if necessary.
+	 *   This is important to not force a storage enlargement just because a single chain is full.
+	 *
+	 * This way, the set can be configured to have a maximum hash table length of a certain size (e.g. 1 GB)
+	 * and from then on grow only by having larger and larger chains.
+	 * This creates multiple memory segments that can be allocated and swapped step by step
+	 * without the need to allocate one gigantic block that exceeds the hardware's memory.
+	 *
+	 * The tradeoff between hash table size and chain length can be perfectly configured
+	 * using a few simple int values. (maximum hash table length, chain length, chains per block, etc.)
+	 */
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// constants //
+	//////////////
+
+	private static final long EMPTY = 0L;
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+
+	/**
+	 * Returns the default initial capacity ({@code 1024}) used by {@link #New()}
+	 * when no explicit capacity is specified.
+	 *
+	 * @return the default initial capacity, always a power of two.
+	 */
+	public static long defaultInitialCapacity()
+	{
+		return 1L<<10;
+	}
+
+	/**
+	 * Returns the default collision threshold, i.e. the number of collisions during an
+	 * insertion that are tolerated before the {@linkplain #defaultExcessLimit() excess counter}
+	 * starts to be incremented.
+	 *
+	 * @return the default collision threshold.
+	 */
+	public static int defaultCollisionThreshold()
+	{
+		return 8;
+	}
+
+	/**
+	 * Returns the default collision limit, i.e. the number of collisions during a single
+	 * insertion that immediately triggers an enlargement of the backing storage.
+	 *
+	 * @return the default collision limit, derived from the {@linkplain #defaultCollisionThreshold() default collision threshold}.
+	 */
+	public static int defaultCollisionLimit()
+	{
+		return deriveCollisionLimit(defaultCollisionThreshold());
+	}
+
+	/**
+	 * Derives a collision limit from the given collision threshold. The limit is always
+	 * a multiple of the threshold and represents the hard per-insertion limit after which
+	 * the storage is enlarged regardless of the excess counter.
+	 *
+	 * @param collisionThreshold the collision threshold to derive the limit from.
+	 * @return the derived collision limit.
+	 */
+	public static int deriveCollisionLimit(final int collisionThreshold)
+	{
+		return collisionThreshold * 8;
+	}
+
+	/**
+	 * Returns the default excess limit, i.e. the number of insertions exceeding the
+	 * {@linkplain #defaultCollisionThreshold() collision threshold} that are tolerated
+	 * before the backing storage is enlarged.
+	 *
+	 * @return the default excess limit.
+	 */
+	public static int defaultExcessLimit()
+	{
+		return 64;
+	}
+
+	/**
+	 * Rounds the given desired capacity up to the next power of two. Since the set relies on
+	 * a power-of-two capacity for its hash masking, this method is used internally to normalize
+	 * capacities supplied by callers.
+	 *
+	 * @param desiredCapacity the desired (minimum) capacity; must be positive.
+	 * @return the smallest power of two that is greater than or equal to {@code desiredCapacity}.
+	 * @throws IllegalArgumentException if {@code desiredCapacity} is not positive.
+	 */
+	public static long padCapacity(final long desiredCapacity)
+	{
+		XMath.positive(desiredCapacity);
+
+		long capacity = 1;
+		while(capacity < desiredCapacity)
+		{
+			capacity <<= 1;
+		}
+
+		return capacity;
+	}
+
+
+
+	/**
+	 * Creates a new {@link OffHeapLongHashSet} with all-default configuration values.
+	 *
+	 * @return the new set instance.
+	 * @see #defaultInitialCapacity()
+	 * @see #defaultCollisionThreshold()
+	 * @see #defaultCollisionLimit()
+	 * @see #defaultExcessLimit()
+	 */
+	public static OffHeapLongHashSet New()
+	{
+		return new OffHeapLongHashSet(
+			defaultInitialCapacity(),
+			defaultCollisionThreshold(),
+			defaultCollisionLimit(),
+			defaultExcessLimit()
+		);
+	}
+
+	/**
+	 * Creates a new {@link OffHeapLongHashSet} with the given initial capacity and otherwise
+	 * default configuration. The capacity is rounded up to the next power of two via
+	 * {@link #padCapacity(long)}.
+	 *
+	 * @param desiredCapacity the desired initial capacity; must be positive.
+	 * @return the new set instance.
+	 */
+	public static OffHeapLongHashSet New(final long desiredCapacity)
+	{
+		return new OffHeapLongHashSet(
+			padCapacity(desiredCapacity),
+			defaultCollisionThreshold(),
+			defaultCollisionLimit(),
+			defaultExcessLimit()
+		);
+	}
+
+	/**
+	 * Creates a new {@link OffHeapLongHashSet} with the given initial capacity and collision
+	 * threshold. The collision limit is {@linkplain #deriveCollisionLimit(int) derived} from
+	 * the threshold, and the excess limit defaults to {@link #defaultExcessLimit()}.
+	 *
+	 * @param desiredCapacity    the desired initial capacity; must be positive.
+	 * @param collisionThreshold the collision threshold; must be positive.
+	 * @return the new set instance.
+	 */
+	public static OffHeapLongHashSet New(final long desiredCapacity, final int collisionThreshold)
+	{
+		return new OffHeapLongHashSet(
+			padCapacity(desiredCapacity),
+			XMath.positive(collisionThreshold),
+			deriveCollisionLimit(collisionThreshold),
+			defaultExcessLimit()
+		);
+	}
+
+	/**
+	 * Creates a new {@link OffHeapLongHashSet} with fully custom configuration values.
+	 *
+	 * @param desiredCapacity    the desired initial capacity; must be positive. Rounded up to the next power of two.
+	 * @param collisionThreshold the number of collisions during a single insertion tolerated before the excess counter is incremented; must be positive.
+	 * @param collisionLimit     the hard per-insertion collision count that triggers a storage enlargement; must be positive.
+	 * @param excessLimit        the number of excess incidents tolerated before a storage enlargement is triggered; must be positive.
+	 * @return the new set instance.
+	 */
+	public static OffHeapLongHashSet New(
+		final long desiredCapacity   ,
+		final int  collisionThreshold,
+		final int  collisionLimit    ,
+		final int  excessLimit
+	)
+	{
+		return new OffHeapLongHashSet(
+			padCapacity(desiredCapacity),
+			XMath.positive(collisionThreshold),
+			XMath.positive(collisionLimit),
+			XMath.positive(excessLimit)
+		);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// instance fields //
+	////////////////////
+
+	// configuration values.
+	private final int collisionThreshold, collisionLimit, excessLimit; // It's a hash COLLISION! Not a "probe"!
+
+	private ByteBuffer dbb;
+	private long dbbBaseAddress;
+
+	private long capacity ; // number of long value slots, always 2^n.
+	private long hashRange; // shortcut for capacity - 1
+
+	private boolean containsZero = false;
+	private long    size         = 0;
+	private int     excessCount  = 0;
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	OffHeapLongHashSet(
+		final long initialCapacity   ,
+		final int  collisionThreshold,
+		final int  collisionLimit    ,
+		final int  excessLimit
+	)
+	{
+		super();
+		this.collisionThreshold = collisionThreshold;
+		this.collisionLimit     = collisionLimit    ;
+		this.excessLimit        = excessLimit       ;
+		this.resize(initialCapacity);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+
+	/**
+	 * Returns whether this set contains the given value.
+	 *
+	 * @param value the value to look up.
+	 * @return {@code true} if the value is contained, {@code false} otherwise.
+	 */
+	public boolean contains(final long value)
+	{
+		if(value == EMPTY)
+		{
+			return this.containsZero;
+		}
+
+		int collisions = 0;
+		for(long i = this.hash(value); collisions < this.collisionLimit; i = this.advanceIndex(i))
+		{
+			final long slotValue = this.getValue(i);
+			if(slotValue == EMPTY)
+			{
+				return false;
+			}
+			if(slotValue == value)
+			{
+				return true;
+			}
+			collisions++;
+		}
+		return false;
+	}
+
+	/**
+	 * Returns whether this set contains all the given values.
+	 *
+	 * @param values the values to look up.
+	 * @return {@code true} if every given value is contained, {@code false} if at least one is missing.
+	 */
+	public boolean containsAll(final long... values)
+	{
+		for(final long value : values)
+		{
+			if(!this.contains(value))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Inserts all given values into this set, skipping values that are already contained.
+	 *
+	 * @param values the values to insert.
+	 * @return the number of values that were actually inserted (i.e. values not previously contained).
+	 */
+	public int putAll(final long... values)
+	{
+		int insertCount = 0;
+		for(final long value : values)
+		{
+			if(this.put(value))
+			{
+				insertCount++;
+			}
+		}
+
+		return insertCount;
+	}
+	/**
+	 * Inserts the given value into this set if it is not already contained. If the configured
+	 * collision thresholds are exceeded, the backing storage is enlarged and all contained
+	 * values are rehashed before the insertion completes.
+	 *
+	 * @param value the value to insert.
+	 * @return {@code true} if the value was inserted, {@code false} if it was already contained.
+	 */
+	public boolean put(final long value)
+	{
+		if(value == EMPTY)
+		{
+			return this.ensureInsertedZero();
+		}
+
+		/*!*\ NOTE:
+		 * This algorithm does intentionally NOT use "tombstones"
+		 * since the purpose of this implementation is only to collect and lookup.
+		 * So if removal should be added, this must be enhanced accordingly.
+		 * However, an enhanced version of this implementation should use
+		 * a segmented chain hashing strategy instead, so using tombstones
+		 * here is irrelevant anyway.
+		 */
+
+		int collisions = 0;
+		for(long i = this.hash(value); true; i = this.advanceIndex(i))
+		{
+			final long slotValue = this.getValue(i);
+			if(slotValue == EMPTY)
+			{
+				this.insertAt(i, value); // empty slot found, insert and return.
+				return true;
+			}
+			if(slotValue == value)
+			{
+				return false; // value already contained
+			}
+			this.checkForRebuild(++collisions); // check for rebuild before trying again.
+		}
+	}
+
+	private long advanceIndex(final long index)
+	{
+		return index >= this.hashRange ? 0 : index + 1;
+	}
+
+
+	private long hash(final long value)
+	{
+		return calculateHashValue(value) & this.hashRange;
+	}
+
+	private void setValue(final long i, final long value)
+	{
+		XMemory.set_long(this.toAddress(i), value);
+	}
+
+	private long getValue(final long i)
+	{
+		return XMemory.get_long(this.toAddress(i));
+	}
+
+	private long toAddress(final long i)
+	{
+		return this.dbbBaseAddress + to_longByteSize(i);
+	}
+
+	private static long to_longByteSize(final long i)
+	{
+		return i << 3;
+	}
+
+	private void checkForRebuild(final int collisions)
+	{
+		if(collisions < this.collisionThreshold)
+		{
+			return; // Acceptable number of collisions.
+		}
+
+		if(collisions >= this.collisionLimit || ++this.excessCount >= this.excessLimit)
+		{
+			this.enlarge(); // Unacceptable number of collisions, enlarge storage.
+		}
+	}
+
+	private boolean ensureInsertedZero()
+	{
+		if(this.containsZero)
+		{
+			return false; // zero already contained
+		}
+
+		this.containsZero = true;
+		this.size++;
+
+		return true;
+	}
+
+	private void insertAt(final long index, final long value)
+	{
+		this.setValue(index , value);
+		this.size++;
+	}
+
+	private static long calculateHashValue(long v)
+	{
+		// Simple but reasonably good mixing for longs.
+		v ^= v >>> 33;
+		v *= 0xff51afd7ed558ccdL;
+		v ^= v >>> 33;
+		v *= 0xc4ceb9fe1a85ec53L;
+		v ^= v >>> 33;
+
+		return v;
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// resizing //
+	/////////////
+
+	private void enlarge()
+	{
+		this.resize(this.capacity << 1);
+	}
+
+	private void resize(final long newCapacity)
+	{
+		// DirectByteBuffer allocation
+		final long newByteCapacity = to_longByteSize(newCapacity);
+		final ByteBuffer newDbb = XMemory.allocateDirectNative(newByteCapacity);
+		final long newBaseAddress = XMemory.getDirectByteBufferAddress(newDbb);
+		XMemory.clearMemory(newBaseAddress, newByteCapacity);
+
+		// rehash all existing elements
+		if(this.size > 0 && this.dbb != null)
+		{
+			this.rebuildTo(newBaseAddress, newCapacity);
+		}
+
+		// DirectByteBuffer management
+		XMemory.deallocateDirectByteBuffer(this.dbb); // explicit deallocation to free huge memory chunks before GC run.
+		this.dbb = newDbb;
+		this.dbbBaseAddress = newBaseAddress;
+
+		// Updated logic state
+		this.capacity = newCapacity;
+		this.hashRange = newCapacity - 1;
+		this.excessCount = 0;
+	}
+
+	private void rebuildTo(final long newBaseAddress, final long newCapacity)
+	{
+		for(long i = 0; i < this.capacity; i++)
+		{
+			final long value = this.getValue(i);
+			if(value != EMPTY)
+			{
+				// All already contained values are guaranteed to fit nicely in an even bigger space.
+				insertBlind(newBaseAddress, newCapacity, value);
+			}
+		}
+	}
+
+	private static void insertBlind(final long baseAddress, final long capacity, final long value)
+	{
+		final long hashRange = capacity - 1;
+		for(long i = calculateHashValue(value) & hashRange; true; i = i >= hashRange ? 0 : i + 1)
+		{
+			final long current = XMemory.get_long(baseAddress + to_longByteSize(i));
+			if(current == EMPTY)
+			{
+				XMemory.set_long(baseAddress + to_longByteSize(i), value);
+				return;
+			}
+		}
+	}
+
+
+
+	/**
+	 * Returns the number of values currently contained in this set.
+	 *
+	 * @return the current size.
+	 */
+	public long size()
+	{
+		return this.size;
+	}
+
+	/**
+	 * Returns the current capacity of the backing off-heap storage, in number of {@code long} slots.
+	 * The capacity is always a power of two and grows only via storage enlargement.
+	 *
+	 * @return the current capacity.
+	 */
+	public long capacity()
+	{
+		return this.capacity;
+	}
+
+	/**
+	 * Returns the current load factor of this set, i.e. the ratio of {@linkplain #size() size}
+	 * to {@linkplain #capacity() capacity}.
+	 *
+	 * @return a value in {@code [0.0, 1.0]}, or {@code 0.0} if the capacity is zero.
+	 */
+	public double currentLoad()
+	{
+		return this.capacity == 0 ? 0.0 : (double)this.size / this.capacity;
+	}
+
+}

--- a/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
+++ b/base/src/main/java/org/eclipse/serializer/collections/OffHeapLongHashSet.java
@@ -34,10 +34,15 @@ import java.nio.ByteBuffer;
  * memory chunks immediately instead of waiting for garbage collection.
  * <p>
  * Instances are not safe for concurrent modification by multiple threads.
+ * <p>
+ * The backing direct buffer holds off-heap memory that is not released by ordinary garbage
+ * collection in a timely manner. Callers must invoke {@link #close()} (e.g. via
+ * try-with-resources) when the set is no longer needed to free the native memory immediately.
+ * After {@code close()}, the set must not be used again.
  *
  * @see XMemory
  */
-public final class OffHeapLongHashSet
+public final class OffHeapLongHashSet implements AutoCloseable
 {
 	/* TODO: OffHeapLongHashSet memory segmentation
 	 * Currently, this implementation can theoretically grow very large (as long as enough
@@ -574,6 +579,29 @@ public final class OffHeapLongHashSet
 	public double currentLoad()
 	{
 		return this.capacity == 0 ? 0.0 : (double)this.size / this.capacity;
+	}
+
+	/**
+	 * Releases the off-heap memory backing this set. After this call the set must not be
+	 * used anymore; further calls to {@link #put(long)}, {@link #contains(long)}, etc. will
+	 * produce undefined results. Calling {@code close()} more than once is a no-op.
+	 */
+	@Override
+	public void close()
+	{
+		final ByteBuffer buffer = this.dbb;
+		if(buffer == null)
+		{
+			return; // already closed
+		}
+		this.dbb            = null;
+		this.dbbBaseAddress = 0L;
+		this.capacity       = 0L;
+		this.hashRange      = 0L;
+		this.size           = 0L;
+		this.excessCount    = 0;
+		this.containsZero   = false;
+		XMemory.deallocateDirectByteBuffer(buffer);
 	}
 
 }

--- a/base/src/main/java/org/eclipse/serializer/collections/Set_long.java
+++ b/base/src/main/java/org/eclipse/serializer/collections/Set_long.java
@@ -334,9 +334,11 @@ public interface Set_long extends Composition, _longIterable, Sized
 		{
 			// +1 so that an exact power-of-two size doesn't leave us at size >= hashRange
 			// and trigger an immediate re-enlarge on the next add.
+			// Cap at the highest power-of-two int (2^30) to preserve the power-of-two invariant
+			// that hash() relies on (hashRange must be 2^n - 1).
 			final long desired = this.size + 1L;
-			final int targetLength = desired >= Integer.MAX_VALUE
-				? Integer.MAX_VALUE
+			final int targetLength = desired >= XMath.highestPowerOf2_int()
+				? XMath.highestPowerOf2_int()
 				: XMath.pow2BoundCapped((int)desired);
 			this.rebuild(targetLength);
 			return this.size;

--- a/base/src/main/java/org/eclipse/serializer/collections/Set_long.java
+++ b/base/src/main/java/org/eclipse/serializer/collections/Set_long.java
@@ -66,6 +66,19 @@ public interface Set_long extends Composition, _longIterable, Sized
 	public final class Default implements Set_long
 	{
 		///////////////////////////////////////////////////////////////////////////
+		// constants //
+		//////////////
+
+		/**
+		 * Sentinel value used in the chain arrays to mark an empty slot.
+		 * Since this collides with the legitimate value {@code 0L}, the presence of {@code 0L}
+		 * as an actual element is tracked separately via {@link #containsZero}.
+		 */
+		private static final long EMPTY = 0L;
+
+
+
+		///////////////////////////////////////////////////////////////////////////
 		// static methods //
 		///////////////////
 
@@ -93,7 +106,8 @@ public interface Set_long extends Composition, _longIterable, Sized
 
 		private long[][] hashSlots;
 		private int      hashRange;
-		private int      size     ;
+		private long     size     ;
+		private boolean  containsZero;
 
 		private final int chainInitialLength;
 		private final float chainGrowthFactor;
@@ -109,7 +123,8 @@ public interface Set_long extends Composition, _longIterable, Sized
 			super();
 			this.hashSlots = new long[(this.hashRange = XMath.pow2BoundCapped(slotSize) - 1) + 1][];
 			this.chainInitialLength = XMath.positive(chainDefaultLength);
-			this.chainGrowthFactor  = XMath.positive(chainGrowthFactor);
+			// chainGrowthFactor below 1.0 would shrink the chain on enlargement; clamp to avoid pathological shrinking.
+			this.chainGrowthFactor  = Math.max(1.0f, XMath.positive(chainGrowthFactor));
 		}
 
 
@@ -138,7 +153,7 @@ public interface Set_long extends Composition, _longIterable, Sized
 
 		private void rebuild(final int newLength)
 		{
-			if(this.hashSlots.length >= newLength || newLength <= 0)
+			if(newLength <= 0 || newLength == this.hashSlots.length)
 			{
 				return;
 			}
@@ -165,13 +180,27 @@ public interface Set_long extends Composition, _longIterable, Sized
 		{
 			for(final long element : oldChain)
 			{
+				if(element == EMPTY)
+				{
+					// elements are packed from index 0; a sentinel means the rest is empty.
+					break;
+				}
 				this.addElement(newSlots, hash(element,  newRange), element);
 			}
 		}
 
 		private static int hash(final long element, final int hashRange)
 		{
-			return (int)(element & hashRange);
+			// MurmurHash3 64-bit finalizer (fmix64) by Austin Appleby — diffuses every input bit
+			// into every output bit so the low bits used for bucketing don't mirror the raw input.
+			// See https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp (fmix64).
+			long v = element;
+			v ^= v >>> 33;
+			v *= 0xff51afd7ed558ccdL;
+			v ^= v >>> 33;
+			v *= 0xc4ceb9fe1a85ec53L;
+			v ^= v >>> 33;
+			return (int)(v & hashRange);
 		}
 
 		private boolean addElement(final long[][] hashSlots, final int hashIndex, final long element)
@@ -179,10 +208,10 @@ public interface Set_long extends Composition, _longIterable, Sized
 			final long[] chain;
 			if((chain = hashSlots[hashIndex]) != null)
 			{
-				// normal case: search for an empty slot (0L) in an existing chain
+				// normal case: search for an empty slot (EMPTY) in an existing chain
 				for(int n = 0; n < chain.length; n++)
 				{
-					if(chain[n] == 0L)
+					if(chain[n] == EMPTY)
 					{
 						// found empty slot after the last element
 						chain[n] = element;
@@ -218,6 +247,18 @@ public interface Set_long extends Composition, _longIterable, Sized
 		@Override
 		public final boolean add(final long element)
 		{
+			if(element == EMPTY)
+			{
+				// EMPTY (= 0L) is the chain-array sentinel, so an actual 0L must be tracked separately.
+				if(this.containsZero)
+				{
+					return false;
+				}
+				this.containsZero = true;
+				this.size++;
+				return true;
+			}
+
 			if(!this.addElement(this.hashSlots, hash(element, this.hashRange), element))
 			{
 				return false;
@@ -234,14 +275,26 @@ public interface Set_long extends Composition, _longIterable, Sized
 		@Override
 		public final boolean contains(final long element)
 		{
-			if(element != 0L)
+			if(element == EMPTY)
 			{
-				for(final long e : this.hashSlots[hash(element, this.hashRange)])
+				return this.containsZero;
+			}
+
+			final long[] chain = this.hashSlots[hash(element, this.hashRange)];
+			if(chain == null)
+			{
+				return false;
+			}
+			for(final long e : chain)
+			{
+				if(e == element)
 				{
-					if(e == element)
-					{
-						return true;
-					}
+					return true;
+				}
+				if(e == EMPTY)
+				{
+					// chain elements are packed from index 0; a sentinel means no further elements.
+					return false;
 				}
 			}
 
@@ -251,6 +304,10 @@ public interface Set_long extends Composition, _longIterable, Sized
 		@Override
 		public void iterate(final _longProcedure procedure)
 		{
+			if(this.containsZero)
+			{
+				procedure.accept(EMPTY);
+			}
 			final long[][] hashSlots = this.hashSlots;
 			for(int i = 0; i < hashSlots.length; i++)
 			{
@@ -260,7 +317,7 @@ public interface Set_long extends Composition, _longIterable, Sized
 				}
 				for(final long e : hashSlots[i])
 				{
-					if(e == 0L)
+					if(e == EMPTY)
 					{
 						break;
 					}
@@ -275,7 +332,13 @@ public interface Set_long extends Composition, _longIterable, Sized
 		 */
 		public long optimize()
 		{
-			this.rebuild(XMath.pow2BoundCapped(this.size));
+			// +1 so that an exact power-of-two size doesn't leave us at size >= hashRange
+			// and trigger an immediate re-enlarge on the next add.
+			final long desired = this.size + 1L;
+			final int targetLength = desired >= Integer.MAX_VALUE
+				? Integer.MAX_VALUE
+				: XMath.pow2BoundCapped((int)desired);
+			this.rebuild(targetLength);
 			return this.size;
 		}
 
@@ -288,19 +351,26 @@ public interface Set_long extends Composition, _longIterable, Sized
 				slots[i] = null;
 			}
 			this.size = 0;
+			this.containsZero = false;
 		}
 
 		@Override
 		public void truncate()
 		{
-			this.hashSlots = new long[1][];
-			this.size = 0;
+			this.hashSlots    = new long[1][];
+			this.hashRange    = 0;
+			this.size         = 0;
+			this.containsZero = false;
 		}
 
 		@Override
 		public Set_long.Default filter(final _longPredicate selector)
 		{
-			final Set_long.Default result = new Set_long.Default(1, this.chainInitialLength, this.chainGrowthFactor);
+			// Seed with the current slot count so a large source set does not cause log(n) rebuilds
+			// during the filter pass.
+			final Set_long.Default result = new Set_long.Default(
+				this.hashSlots.length, this.chainInitialLength, this.chainGrowthFactor
+			);
 
 			this.iterate(e ->
 			{

--- a/base/src/main/java/org/eclipse/serializer/collections/XArrays.java
+++ b/base/src/main/java/org/eclipse/serializer/collections/XArrays.java
@@ -153,6 +153,86 @@ public final class XArrays
 		}
 	}
 
+	public static boolean hasNoContent(final byte[] array)
+	{
+		return array == null || array.length == 0;
+	}
+
+	public static boolean hasNoContent(final short[] array)
+	{
+		return array == null || array.length == 0;
+	}
+
+	public static boolean hasNoContent(final int[] array)
+	{
+		return array == null || array.length == 0;
+	}
+
+	public static boolean hasNoContent(final long[] array)
+	{
+		return array == null || array.length == 0;
+	}
+
+	public static boolean hasNoContent(final float[] array)
+	{
+		return array == null || array.length == 0;
+	}
+
+	public static boolean hasNoContent(final double[] array)
+	{
+		return array == null || array.length == 0;
+	}
+
+	public static boolean hasNoContent(final boolean[] array)
+	{
+		return array == null || array.length == 0;
+	}
+
+	public static boolean hasNoContent(final char[] array)
+	{
+		return array == null || array.length == 0;
+	}
+
+	public static boolean hasContent(final byte[] array)
+	{
+		return !hasNoContent(array);
+	}
+
+	public static boolean hasContent(final short[] array)
+	{
+		return !hasNoContent(array);
+	}
+
+	public static boolean hasContent(final int[] array)
+	{
+		return !hasNoContent(array);
+	}
+
+	public static boolean hasContent(final long[] array)
+	{
+		return !hasNoContent(array);
+	}
+
+	public static boolean hasContent(final float[] array)
+	{
+		return !hasNoContent(array);
+	}
+
+	public static boolean hasContent(final double[] array)
+	{
+		return !hasNoContent(array);
+	}
+
+	public static boolean hasContent(final boolean[] array)
+	{
+		return !hasNoContent(array);
+	}
+
+	public static boolean hasContent(final char[] array)
+	{
+		return !hasNoContent(array);
+	}
+
 	/**
 	 * Returns if the passed array is either null or has the length 0.
 	 *

--- a/base/src/main/java/org/eclipse/serializer/hashing/XHashing.java
+++ b/base/src/main/java/org/eclipse/serializer/hashing/XHashing.java
@@ -195,14 +195,14 @@ public final class XHashing
 		final HashEqualator<? super K> hashEqualator
 	)
 	{
-		return new HashEqualator<KeyValue<K, V>>()
+		return new HashEqualator<>()
 		{
 			@Override
 			public int hash(final KeyValue<K, V> kv)
 			{
 				return kv == null ? 0 : hashEqualator.hash(kv.key());
 			}
-			
+
 			@Override
 			public boolean equal(final KeyValue<K, V> kv1, final KeyValue<K, V> kv2)
 			{
@@ -217,6 +217,11 @@ public final class XHashing
 			? XHashing.hashEqualityValue()
 			: XHashing.hashEqualityIdentity()
 			;
+	}
+
+	public static int hash(final int hash1, final int hash2)
+	{
+		return 31 * hash1 + hash2;
 	}
 	
 	


### PR DESCRIPTION
### Summary

This pull request introduces the following changes:
- Added `OffHeapLongHashSet` for efficient storage and retrieval of long values.
- Added the `isEmpty` override and `padLeft` utility method for better usability.
- Introduced a utility method for combined hash calculation.
- Added array content check utility methods to simplify array handling.
- Fix correctness and performance issues in `Set_long`
