### PR TITLE
Improve documentation for Persister and Storer interfaces

### DIFF
--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/Persister.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/Persister.java
@@ -21,72 +21,187 @@ import java.time.Duration;
 public interface Persister extends ObjectSwizzling, PersistenceStoring
 {
 	/**
-	 * {@inheritDoc}
+	 * Returns the object instance associated with the passed objectId in this {@link Persister}'s
+	 * {@link PersistenceObjectRegistry}, loading it from the persistent form if necessary.
+	 * <p>
+	 * The objectId is the value previously returned by {@link #store(Object)} (or by an earlier load
+	 * of the same instance). For an unknown objectId the behavior is implementation-defined &mdash;
+	 * typical implementations either return {@code null} or throw a persistence exception; consult
+	 * the concrete implementation.
+	 *
+	 * @param objectId the objectId of the instance to retrieve.
+	 *
+	 * @return the instance associated with {@code objectId}.
+	 *
+	 * @see #store(Object)
 	 */
 	@Override
 	public Object getObject(long objectId);
 
 	/**
-	 * {@inheritDoc}
+	 * Persists the passed object instance. The object's value fields are written and recursively
+	 * referenced object instances are inspected as well.
+	 * <p>
+	 * <b>Lazy default semantics.</b> The default storer (see {@link #createLazyStorer()}) persists
+	 * only referenced instances that are not yet known to this {@link Persister}'s
+	 * {@link PersistenceObjectRegistry} (i.e. that do not yet have an objectId associated with them).
+	 * Already-known references are <i>not</i> traversed and any modifications to their fields will
+	 * <b>not</b> be picked up by this call. To persist modifications to an existing object, call
+	 * {@code store(Object)} on that very object &mdash; the rule is: <i>"the object that has been
+	 * modified has to be stored"</i>. To force recursive re-storing of already-known instances, use
+	 * {@link #createEagerStorer()}.
+	 * <p>
+	 * <b>Atomicity.</b> A single {@code store(...)} call is atomic: either all data produced by it is
+	 * committed, or none of it is. There are no partially applied stores.
+	 * <p>
+	 * <b>Durability.</b> When this {@link Persister} is backed by a persistent storage layer (e.g.
+	 * EclipseStore Storage), the data written by this call is guaranteed to be physically committed
+	 * by the time this method returns. A process crash before that point cannot leave the storage in
+	 * an inconsistent state &mdash; the next start resumes from the last fully committed store.
+	 * <p>
+	 * <b>Concurrency.</b> {@code store(...)} does not synchronize the in-memory object graph for the
+	 * caller. The mutation of an object and the corresponding {@code store(...)} call must be executed
+	 * under the same lock as any concurrent reader or writer of the affected part of the graph.
+	 * Otherwise other threads may observe partially modified state, or the persisted data may not
+	 * reflect the intended change.
+	 *
+	 * @param instance the object instance to persist.
+	 *
+	 * @return the objectId associated with the passed instance. Stable across calls for the same
+	 *         instance once registered.
+	 *
+	 * @see #storeAll(Object...)
+	 * @see #storeAll(Iterable)
+	 * @see #createLazyStorer()
+	 * @see #createEagerStorer()
 	 */
 	@Override
 	public long store(Object instance);
 
 	/**
-	 * {@inheritDoc}
+	 * Convenience overload that persists each of the passed instances using the same default-storer
+	 * semantics as {@link #store(Object)}. The varargs array itself is <b>not</b> persisted &mdash;
+	 * only its elements.
+	 * <p>
+	 * The whole call is atomic: either every element is committed, or none of them is.
+	 * <p>
+	 * See {@link #store(Object)} for the lazy-default rule, durability semantics, and the concurrency
+	 * obligation that apply identically to each element.
+	 *
+	 * @param instances the object instances to persist.
+	 *
+	 * @return the objectIds of the passed instances, in the same order.
+	 *
+	 * @see #store(Object)
+	 * @see #storeAll(Iterable)
 	 */
 	@Override
 	public long[] storeAll(Object... instances);
 
 	/**
-	 * {@inheritDoc}
+	 * Convenience overload that persists each element produced by the passed {@link Iterable} using
+	 * the same default-storer semantics as {@link #store(Object)}. The {@link Iterable} itself is
+	 * <b>not</b> persisted &mdash; only its elements.
+	 * <p>
+	 * The whole call is atomic: either every iterated element is committed, or none of them is.
+	 * <p>
+	 * See {@link #store(Object)} for the lazy-default rule, durability semantics, and the concurrency
+	 * obligation that apply identically to each element.
+	 *
+	 * @param instances the object instances to persist.
+	 *
+	 * @see #store(Object)
+	 * @see #storeAll(Object...)
 	 */
 	@Override
 	public void storeAll(Iterable<?> instances);
 
-	
+
 	/**
-	 * Creates a new {@link Storer} instance with lazy storing behavior. This means an entity instance encountered
-	 * while traversing the entity graph is only stored if it is not yet known to the persistence context, i.e.
-	 * does not have an objectId associated with it in the persistence context's {@link PersistenceObjectRegistry}.
-	 * 
-	 * @return the newly created {@link Storer} instance.
+	 * Creates a new {@link Storer} that uses the <b>lazy</b> storing strategy.
+	 * <p>
+	 * Lazy semantics: a {@code store(...)} call on the returned {@link Storer} persists the passed
+	 * instance and recursively traverses its references, but it persists only those referenced
+	 * instances that are not yet known to this {@link Persister}'s {@link PersistenceObjectRegistry}.
+	 * Already-known references are skipped &mdash; modifications to their fields are <i>not</i>
+	 * persisted by such a call. To persist a modification, call {@code store(...)} on the modified
+	 * object itself.
+	 * <p>
+	 * This is the most common storing strategy and the basis for the default returned by
+	 * {@link #createStorer()}. Choose it for the typical case of "store an updated instance and any
+	 * newly created instances reachable from it; leave already-stored references untouched".
+	 *
+	 * @return a new lazy {@link Storer}.
+	 *
+	 * @see #createStorer()
+	 * @see #createEagerStorer()
 	 */
 	public Storer createLazyStorer();
-	
+
 	/**
-	 * Creates a new {@link Storer} instance with default storing behavior. The default is lazy storing.
-	 * See {@link #createLazyStorer()}.
-	 * 
-	 * @return the newly created {@link Storer} instance.
+	 * Creates a new {@link Storer} using the implementation's configured default storing strategy.
+	 * <p>
+	 * Unless explicitly overridden in the configuration, this returns a lazy storer equivalent to
+	 * {@link #createLazyStorer()}. Use this method when you want to follow the project's chosen
+	 * default; use {@link #createLazyStorer()} / {@link #createEagerStorer()} explicitly when you
+	 * want a specific strategy regardless of configuration.
+	 * <p>
+	 * The returned {@link Storer} is independent of any other storer and must be {@code commit()}-ed
+	 * to actually persist its accumulated state.
+	 *
+	 * @return a new {@link Storer} with the default strategy.
+	 *
+	 * @see #createLazyStorer()
+	 * @see #createEagerStorer()
 	 */
 	public Storer createStorer();
 
 	/**
-	 * Creates a new {@link Storer} instance with eager storing behavior. This means an entity instance encountered
-	 * while traversing the entity graph is always stored, regardless of if it is already known to the persistence
-	 * context or not, i.e. does have an objectId associated with it in the persistence context's
-	 * {@link PersistenceObjectRegistry}.
+	 * Creates a new {@link Storer} that uses the <b>eager</b> storing strategy.
 	 * <p>
-	 * Note: Eager storing is a dangerous behavior since - depending on the entity graph's referential layout -
-	 * it can cause the whole entity graph present in the heap to be stored. Therefore, it is stronly advised to
-	 * instead use lazy storing logic (see {@link #createLazyStorer()}) or some other kind of limiting storing logic.
-	 * 
-	 * @return the newly created {@link Storer} instance.
+	 * Eager semantics: a {@code store(...)} call on the returned {@link Storer} persists the passed
+	 * instance and recursively traverses its references, persisting <i>every</i> reachable instance
+	 * &mdash; including ones already known to this {@link Persister}'s
+	 * {@link PersistenceObjectRegistry}. This guarantees that field-level modifications anywhere in
+	 * the traversed sub-graph are picked up, at the cost of writing data that may not have changed.
+	 * <p>
+	 * Use this strategy when you cannot conveniently call {@code store(...)} on individual modified
+	 * objects (e.g. encapsulated objects without accessors), or when bulk-storing immutable
+	 * sub-graphs. For finer control over which specific reference fields are evaluated eagerly,
+	 * configure a {@code PersistenceEagerStoringFieldEvaluator} instead of switching the global
+	 * strategy.
+	 *
+	 * @return a new eager {@link Storer}.
+	 *
+	 * @see #createStorer()
+	 * @see #createLazyStorer()
 	 */
 	public Storer createEagerStorer();
 
 	/**
-	 * Creates a new {@link BatchStorer} instance with lazy storing semantics for child objects
-	 * and forced re-serialization for explicitly stored root instances.
+	 * Creates a new {@link BatchStorer} that buffers store requests and commits them in batches
+	 * under the control of the passed {@link BatchStorer.Controller}.
+	 * <p>
+	 * A {@link BatchStorer} is useful when many small store operations would otherwise each trigger
+	 * an individual commit round-trip. The controller decides when an accumulated batch is committed
+	 * (e.g. by element count or accumulated size); {@code checkInterval} bounds how long a pending
+	 * batch may sit unflushed before the controller is consulted again.
+	 * <p>
+	 * The lazy-default semantics described on {@link #store(Object)} apply to each individual store
+	 * request submitted to the {@link BatchStorer}. Atomicity holds <i>per committed batch</i>, not
+	 * per individual {@code store(...)} call submitted to it.
 	 *
-	 * @param controller    controls when accumulated data should be flushed
-	 * @param checkInterval the interval at which a background thread checks for pending flushes
-	 * @return the newly created {@link BatchStorer} instance.
+	 * @param controller    decides when a buffered batch is committed.
+	 * @param checkInterval maximum time between controller evaluations of the pending batch.
+	 *
+	 * @return a new {@link BatchStorer}.
+	 *
+	 * @see #createStorer()
+	 * @see BatchStorer
 	 */
 	public default BatchStorer createBatchStorer(
-		BatchStorer.Controller controller   ,
-		Duration               checkInterval
+		final BatchStorer.Controller controller   ,
+		final Duration               checkInterval
 	)
 	{
 		throw new UnsupportedOperationException(

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/Storer.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/Storer.java
@@ -1,7 +1,5 @@
 package org.eclipse.serializer.persistence.types;
 
-import org.eclipse.serializer.persistence.exceptions.PersistenceExceptionConsistencyObject;
-
 /*-
  * #%L
  * Eclipse Serializer Persistence
@@ -11,57 +9,95 @@ import org.eclipse.serializer.persistence.exceptions.PersistenceExceptionConsist
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  * #L%
  */
 
+import org.eclipse.serializer.persistence.exceptions.PersistenceExceptionConsistencyObject;
+
 /**
- * A type extending the simple {@link PersistenceStoring} to enable stateful store handling.
- * This can be used to do what is generally called "transactions": preprocess data to be stored and then store
- * either all or nothing.<br>
- * It can also be used to skip certain references. See {@link #skip(Object)}<br>
- * The deviating naming (missing "Persistence" prefix) is intentional to support convenience
- * on the application code level.
+ * A {@link PersistenceStoring} variant with stateful, transaction-like store handling.
+ * <p>
+ * Lifecycle of a {@link Storer} instance:
+ * <ol>
+ *   <li><b>Collect.</b> One or more {@code store(...)} / {@link #skip(Object)} /
+ *       {@link #skipMapped(Object, long)} / {@link #skipNulled(Object)} calls accumulate state
+ *       inside this {@link Storer} <i>without</i> writing anything to the underlying
+ *       {@link PersistenceObjectRegistry} or persistent storage.</li>
+ *   <li><b>Commit.</b> A single {@link #commit()} call atomically persists everything that has
+ *       been accumulated. Either all of it is committed or none of it is.</li>
+ *   <li><b>Reuse or discard.</b> After {@code commit()}, the storer can be reused
+ *       ({@link #clear()} / {@link #reinitialize()}) or simply dropped.</li>
+ * </ol>
+ * The deviating naming (missing "Persistence" prefix) is intentional to support convenience on
+ * the application code level.
  *
- * 
+ * @see PersistenceStoring
  */
 public interface Storer extends PersistenceStoring
 {
 	/**
-	 * Ends the data collection process and causes all collected data to be persisted.
+	 * Ends the data collection process and persists all data accumulated by previous
+	 * {@code store(...)} calls on this {@link Storer}.
 	 * <p>
-	 * This is an atomatic all-or-nothing operation: either all collected data will be persisted successfully,
-	 * or non of it will be persisted. Partially persisted data will be reverted / rolled back in case of a failure.
+	 * This is an atomic all-or-nothing operation: either all collected data is persisted successfully,
+	 * or none of it is. Partially persisted data is reverted on failure, leaving the underlying
+	 * storage and the {@link PersistenceObjectRegistry} unchanged.
+	 * <p>
+	 * After {@code commit()} returns successfully, every instance accumulated by this storer has an
+	 * objectId registered in the {@link PersistenceObjectRegistry}. Subsequent {@code store(...)}
+	 * calls on those same instances by <i>any</i> storer will follow the lazy-default rule and skip
+	 * them unless an eager strategy is used.
+	 * <p>
+	 * The method may be called at most once on a fresh storer state. To reuse the storer, call
+	 * {@link #clear()} or {@link #reinitialize()} afterwards.
 	 *
-	 * @return some kind of status information, potentially null.
+	 * @return implementation-specific status information about the commit, or {@code null} if the
+	 *         implementation does not provide any.
+	 *
+	 * @see #clear()
+	 * @see #reinitialize()
 	 */
 	public Object commit();
 
 	/**
-	 * Clears all internal state regarding collected data and/or registered skips.
+	 * Discards all accumulated state of this {@link Storer}: pending stores collected since the last
+	 * {@code commit()} (or since construction) as well as any registered skips
+	 * ({@link #skip(Object)} / {@link #skipMapped(Object, long)} / {@link #skipNulled(Object)}).
+	 * <p>
+	 * This rolls back uncommitted in-memory state only; data already committed by a previous
+	 * {@link #commit()} call is unaffected. After {@code clear()} the storer is ready to start a new
+	 * collection cycle.
+	 *
+	 * @see #commit()
+	 * @see #reinitialize()
 	 */
 	public void clear();
 
 	/**
-	 * Registers the passed {@literal instance} under the passed {@literal objectId} without persisting its data.
+	 * Registers the passed instance under the passed objectId without collecting its data for
+	 * persistence.
 	 * <p>
-	 * This skip means that if the passed {@literal instance} is encountered while collecting data to be persisted,
-	 * its data will NOT be collected. References to the passed {@literal instance} will be persisted as the
-	 * passed {@literal objectId}.
+	 * If the instance is encountered while traversing references during the collection phase, its
+	 * data is <b>not</b> collected; references to it are persisted using the passed
+	 * {@code objectId} instead. This effectively redirects all references to the passed instance
+	 * to whatever persistent record is associated with {@code objectId}.
 	 * <p>
-	 * <u>Warning</u>:<br>
-	 * This method can be very useful to rearrange object graphs on the persistence level, but it can also cause
-	 * inconsistencies if not used perfectly correctly.<br>
-	 * It is strongly advised to use one of the following alternatives instead:
-	 * {@link #skip(Object)}
-	 * {@link #skipNulled(Object)}
+	 * <b>Warning.</b> This is a low-level mechanism that can be useful for rearranging object graphs
+	 * on the persistence level (e.g. swapping the target of a reference, ID re-mapping during
+	 * migration), but it can also create inconsistencies if the passed {@code objectId} does not
+	 * point to a record of a compatible type. Prefer {@link #skip(Object)} or
+	 * {@link #skipNulled(Object)} unless you specifically need ID-level remapping.
+	 * <p>
+	 * Skips are part of the storer's collection state and are discarded by {@link #clear()} or
+	 * {@link #commit()}.
 	 *
-	 * @param instance the instance / reference to be skipped.
-	 *
+	 * @param instance the instance to be skipped.
 	 * @param objectId the objectId to be used as a reference to the skipped instance.
 	 *
-	 * @return {@literal true} if the instance has been newly registered, {@literal false} if it already was.
+	 * @return {@code true} if the instance was newly registered by this call, {@code false} if it
+	 *         was already registered.
 	 *
 	 * @see #skip(Object)
 	 * @see #skipNulled(Object)
@@ -69,17 +105,24 @@ public interface Storer extends PersistenceStoring
 	public boolean skipMapped(Object instance, long objectId);
 
 	/**
-	 * Registers the passed {@literal instance} to be skipped from the data persisting process.
+	 * Registers the passed instance to be skipped during this storer's data collection.
 	 * <p>
-	 * This skip means that if the passed {@literal instance} is encountered while collecting data to be persisted,
-	 * its data will NOT be collected. If the instance is already registered under a certain object id at the used
-	 * {@link PersistenceObjectRegistry}, then is associated object id will be used. Otherwise, the null-Id will be
-	 * used, effectively "nulling out" all references to this instance on the persistent level.<br>
-	 * The latter behavior is exactly the same as {@link #skipNulled(Object)}.
+	 * A skipped instance encountered while traversing references is <b>not</b> collected for
+	 * persistence. The reference itself is resolved as follows:
+	 * <ul>
+	 *   <li>If the instance is already registered for an objectId in the
+	 *       {@link PersistenceObjectRegistry}, that existing objectId is used (i.e. the reference
+	 *       still points to the previously persisted instance).</li>
+	 *   <li>Otherwise, the null-id is used &mdash; effectively writing the reference as {@code null}
+	 *       in the persistent form. This matches the behavior of {@link #skipNulled(Object)}.</li>
+	 * </ul>
+	 * Skips are part of the storer's collection state and are discarded by {@link #clear()} or
+	 * {@link #commit()}.
 	 *
-	 * @param instance the instance / reference to be skipped.
+	 * @param instance the instance to be skipped.
 	 *
-	 * @return {@literal true} if the instance has been newly registered, {@literal false} if it already was.
+	 * @return {@code true} if the instance was newly registered as skipped by this call, {@code false}
+	 *         if it was already registered.
 	 *
 	 * @see #skipNulled(Object)
 	 * @see #skipMapped(Object, long)
@@ -87,17 +130,21 @@ public interface Storer extends PersistenceStoring
 	public boolean skip(Object instance);
 
 	/**
-	 * Registers the passed {@literal instance} to be skipped from the data persisting process.
+	 * Registers the passed instance to be skipped during this storer's data collection, with all
+	 * references to it persisted as {@code null}.
 	 * <p>
-	 * This skip means that if the passed {@literal instance} is encountered while collecting data to be persisted,
-	 * its data will NOT be collected. References to this instance will always be persisted as null, no matter if
-	 * the instance is already registered for a certain object id at the used {@link PersistenceObjectRegistry}
-	 * or not.<br>
-	 * To make the skipping consider existing object id registrations, use {@link #skip(Object)}.
+	 * Unlike {@link #skip(Object)}, this method <b>ignores</b> any existing registration of the
+	 * instance in the {@link PersistenceObjectRegistry}: references will be written as {@code null}
+	 * unconditionally. Use {@link #skip(Object)} if you want existing object-id registrations to be
+	 * honored.
+	 * <p>
+	 * Skips are part of the storer's collection state and are discarded by {@link #clear()} or
+	 * {@link #commit()}.
 	 *
-	 * @param instance the instance / reference to be skipped by using .
+	 * @param instance the instance to be skipped.
 	 *
-	 * @return {@literal true} if the instance has been newly registered, {@literal false} if it already was.
+	 * @return {@code true} if the instance was newly registered as nulled by this call,
+	 *         {@code false} if it was already registered.
 	 *
 	 * @see #skip(Object)
 	 * @see #skipMapped(Object, long)
@@ -170,22 +217,78 @@ public interface Storer extends PersistenceStoring
 	 */
 	public Storer ensureCapacity(long desiredCapacity);
 
-	
-	public void registerCommitListener(PersistenceCommitListener listener);
-		
-	public void registerRegistrationListener(PersistenceObjectRegistrationListener listener);
-	
 	/**
-	 * Stores the passed instance with the provided id and all referenced instances of persistable references recursively,
-	 * but stores the passed instance and referenced instances only if they are newly encountered (e.g. don't have an id associated with
-	 * them in the object registry, yet and are therefore required to be handled).
-	 * <br><br>
-	 * If the provided instance is allready persisted with an other id an {@link PersistenceExceptionConsistencyObject} exception
-	 * will be thrown on commit.
-	 * 
-	 * @param instance the root instance of the subgraph of required instances to be stored.
-	 * @param objectId the storage object id which shall be assigned to the passed instance.
-	 * @return the object id representing the passed instance.
+	 * Registers a {@link PersistenceCommitListener} that will be notified when this storer's
+	 * {@link #commit()} successfully completes.
+	 * <p>
+	 * Listeners are invoked synchronously on the thread that called {@code commit()} after all data
+	 * has been persisted and the {@link PersistenceObjectRegistry} has been updated. They are
+	 * therefore suitable for hooking post-commit work (cache invalidation, notifications, metrics)
+	 * that must observe the committed state.
+	 * <p>
+	 * Listeners registered on this storer are scoped to this storer instance and are <i>not</i>
+	 * carried over to other storers. They are retained across {@link #clear()} but discarded by
+	 * {@link #reinitialize()}.
+	 *
+	 * @param listener the listener to register.
+	 */
+	public void registerCommitListener(PersistenceCommitListener listener);
+
+	/**
+	 * Registers a {@link PersistenceObjectRegistrationListener} that will be notified for every
+	 * object that this storer registers in the {@link PersistenceObjectRegistry} during the
+	 * collection phase.
+	 * <p>
+	 * The listener's {@code onObjectRegistration(long, Object)} method is called once per object as
+	 * an objectId is assigned to it. This is useful for diagnostics, auditing, or building
+	 * objectId &rarr; instance maps for committed graphs (see the EclipseStore Storage user docs
+	 * &mdash; "Best Practice / Get objects that are persisted by a storer").
+	 * <p>
+	 * <b>Performance.</b> The listener is invoked synchronously inside the storer's hot path; a
+	 * non-trivial implementation will measurably slow down the collection phase. Keep the callback
+	 * cheap and non-blocking.
+	 * <p>
+	 * Listeners registered on this storer are scoped to this storer instance and are <i>not</i>
+	 * carried over to other storers.
+	 *
+	 * @param listener the listener to register.
+	 */
+	public void registerRegistrationListener(PersistenceObjectRegistrationListener listener);
+
+	/**
+	 * {@inheritDoc}
+	 * <p>
+	 * On a {@link Storer}, this call <b>accumulates</b> the instance and its newly encountered
+	 * references in this storer's internal state without committing anything. The actual persistence
+	 * happens on {@link #commit()}; until then nothing is registered in the
+	 * {@link PersistenceObjectRegistry} and nothing is written to the underlying storage layer.
+	 * Calling {@code store(...)} on the same instance multiple times before {@code commit()} has no
+	 * additional effect.
+	 *
+	 * @see #commit()
+	 * @see #skip(Object)
+	 */
+	@Override
+	public long store(Object instance);
+
+	/**
+	 * Accumulates the passed instance &mdash; together with all newly encountered referenced
+	 * instances reachable from it &mdash; for persistence under the passed {@code objectId}.
+	 * <p>
+	 * Lazy-default semantics apply: only references not yet known to the
+	 * {@link PersistenceObjectRegistry} are traversed; already-known references are skipped.
+	 * <p>
+	 * If the instance is already registered under a <i>different</i> objectId in the
+	 * {@link PersistenceObjectRegistry}, a {@link PersistenceExceptionConsistencyObject} is thrown
+	 * on {@link #commit()}, not from this method.
+	 *
+	 * @param instance the root instance of the sub-graph to be stored.
+	 * @param objectId the objectId to be assigned to the passed instance on commit.
+	 *
+	 * @return the passed {@code objectId} (the same value that will be used on commit).
+	 *
+	 * @see #store(Object)
+	 * @see #commit()
 	 */
 	public long store(Object instance, long objectId);
 


### PR DESCRIPTION

Enhances the Javadoc comments for the `Persister` and `Storer` interfaces, providing detailed explanations about behavior, lifecycle rules, atomicity, durability, and threading. Fixes documentation inaccuracies and aligns wording across methods.