### PR TITLE
Fix isUnchangedStructure always returning false

### DIFF
--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceLegacyTypeMappingResult.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceLegacyTypeMappingResult.java
@@ -109,13 +109,14 @@ public interface PersistenceLegacyTypeMappingResult<D, T>
 		{
 			final PersistenceTypeDefinitionMember legacyMember  = legacy.next() ;
 			final PersistenceTypeDefinitionMember currentMember = current.next();
-			
+
 			// all legacy members must be directly mapped to their order-wise corresponding current member.
-			if(mapping.get(legacyMember) != currentMember)
+			final Similarity<PersistenceTypeDefinitionMember> match = mapping.get(legacyMember);
+			if(match == null || match.targetElement() != currentMember)
 			{
 				return false;
 			}
-			
+
 			// and the types must be the same, of course. Member names are sound and smoke.
 			if(!legacyMember.typeName().equals(currentMember.typeName()))
 			{

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceLegacyTypeMappingResult.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceLegacyTypeMappingResult.java
@@ -117,10 +117,12 @@ public interface PersistenceLegacyTypeMappingResult<D, T>
 				return false;
 			}
 
-			// the persistent structure of the two members must match; equalsStructure handles
-			// every member kind (regular fields, primitive definitions, enum constants, complex
-			// generic fields) via polymorphic dispatch.
-			if(!legacyMember.equalsStructure(currentMember))
+			// the persistent layout of the two members must match. equalsLayout handles every
+			// member kind (regular fields, primitive definitions, enum constants, complex generic
+			// fields) via polymorphic dispatch and intentionally ignores member names: the
+			// mapping/order check above already establishes identity, so a renamed-but-otherwise-
+			// unchanged member still qualifies for the unchanged-structure fast path.
+			if(!legacyMember.equalsLayout(currentMember))
 			{
 				return false;
 			}

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceLegacyTypeMappingResult.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceLegacyTypeMappingResult.java
@@ -17,7 +17,6 @@ package org.eclipse.serializer.persistence.types;
 import static org.eclipse.serializer.util.X.notNull;
 
 import java.util.Iterator;
-import java.util.Objects;
 
 import org.eclipse.serializer.collections.EqHashEnum;
 import org.eclipse.serializer.collections.XUtilsCollection;
@@ -118,19 +117,10 @@ public interface PersistenceLegacyTypeMappingResult<D, T>
 				return false;
 			}
 
-			// and the types must be the same, of course. Member names are sound and smoke.
-			// workaround: primitive-definition members carry a null typeName; compare their bit-layout definition instead.
-			// TODO: find cleaner solution
-			if(legacyMember.isPrimitiveDefinition() && currentMember.isPrimitiveDefinition())
-			{
-				if(!((PersistenceTypeDescriptionMemberPrimitiveDefinition)legacyMember).primitiveDefinition().equals(
-					((PersistenceTypeDescriptionMemberPrimitiveDefinition)currentMember).primitiveDefinition()
-				))
-				{
-					return false;
-				}
-			}
-			else if(!Objects.equals(legacyMember.typeName(), currentMember.typeName()))
+			// the persistent structure of the two members must match; equalsStructure handles
+			// every member kind (regular fields, primitive definitions, enum constants, complex
+			// generic fields) via polymorphic dispatch.
+			if(!legacyMember.equalsStructure(currentMember))
 			{
 				return false;
 			}

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceLegacyTypeMappingResult.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceLegacyTypeMappingResult.java
@@ -17,6 +17,7 @@ package org.eclipse.serializer.persistence.types;
 import static org.eclipse.serializer.util.X.notNull;
 
 import java.util.Iterator;
+import java.util.Objects;
 
 import org.eclipse.serializer.collections.EqHashEnum;
 import org.eclipse.serializer.collections.XUtilsCollection;
@@ -118,7 +119,18 @@ public interface PersistenceLegacyTypeMappingResult<D, T>
 			}
 
 			// and the types must be the same, of course. Member names are sound and smoke.
-			if(!legacyMember.typeName().equals(currentMember.typeName()))
+			// workaround: primitive-definition members carry a null typeName; compare their bit-layout definition instead.
+			// TODO: find cleaner solution
+			if(legacyMember.isPrimitiveDefinition() && currentMember.isPrimitiveDefinition())
+			{
+				if(!((PersistenceTypeDescriptionMemberPrimitiveDefinition)legacyMember).primitiveDefinition().equals(
+					((PersistenceTypeDescriptionMemberPrimitiveDefinition)currentMember).primitiveDefinition()
+				))
+				{
+					return false;
+				}
+			}
+			else if(!Objects.equals(legacyMember.typeName(), currentMember.typeName()))
 			{
 				return false;
 			}

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceTypeDescriptionMember.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceTypeDescriptionMember.java
@@ -133,7 +133,7 @@ public interface PersistenceTypeDescriptionMember
 	 * @param other the description to compare to
 	 * @return if this and the other description's structure are equal
 	 *
-	 * @see #equalDescription(PersistenceTypeDescriptionMember, PersistenceTypeDescriptionMember)
+	 * @see #equalStructure(PersistenceTypeDescriptionMember, PersistenceTypeDescriptionMember)
 	 */
 	public default boolean equalsStructure(final PersistenceTypeDescriptionMember other)
 	{

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceTypeDescriptionMember.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceTypeDescriptionMember.java
@@ -129,15 +129,36 @@ public interface PersistenceTypeDescriptionMember
 	/**
 	 * Structure means equal order of members by type name and simple name.<br>
 	 * Not qualifier, since that is only required for intra-type field identification
-	 * 
+	 *
 	 * @param other the description to compare to
 	 * @return if this and the other description's structure are equal
-	 * 
+	 *
 	 * @see #equalDescription(PersistenceTypeDescriptionMember, PersistenceTypeDescriptionMember)
 	 */
 	public default boolean equalsStructure(final PersistenceTypeDescriptionMember other)
 	{
 		return equalTypeAndName(this, other);
+	}
+
+	/**
+	 * Like {@link #equalsStructure(PersistenceTypeDescriptionMember)} but ignores the member's
+	 * simple name. Compares only the persistent layout (type name; for primitive-definition members
+	 * the bit-layout descriptor; for complex generic fields the nested members compared again by
+	 * layout).
+	 * <p>
+	 * Used by the "unchanged structure" fast path in legacy-handler creation, where the identity
+	 * correspondence between legacy and current members is already established by the refactoring
+	 * mapping and only the on-disk layout needs to be confirmed &mdash; e.g. a renamed field whose
+	 * type and offset are unchanged still produces the same persisted bytes.
+	 *
+	 * @param other the description to compare to.
+	 * @return if this and the other description's persistent layout are equal.
+	 *
+	 * @see #equalLayout(PersistenceTypeDescriptionMember, PersistenceTypeDescriptionMember)
+	 */
+	public default boolean equalsLayout(final PersistenceTypeDescriptionMember other)
+	{
+		return other != null && Objects.equals(this.typeName(), other.typeName());
 	}
 	
 	/**
@@ -202,6 +223,25 @@ public interface PersistenceTypeDescriptionMember
 	{
 		// must delegate to the implementation since complex fields must deep-check their nested fields
 		return m1 == m2 || m1 != null && m1.equalsStructure(m2);
+	}
+
+	/**
+	 * Static null-safe counterpart to {@link #equalsLayout(PersistenceTypeDescriptionMember)}.
+	 * Delegation to the instance method is required so that complex (nested) member descriptions
+	 * can deep-check their nested members by layout.
+	 *
+	 * @param m1 the first member.
+	 * @param m2 the second member.
+	 *
+	 * @return {@code true} if both members have equal persistent layout.
+	 */
+	public static boolean equalLayout(
+		final PersistenceTypeDescriptionMember m1,
+		final PersistenceTypeDescriptionMember m2
+	)
+	{
+		// must delegate to the implementation since complex fields must deep-check their nested fields
+		return m1 == m2 || m1 != null && m1.equalsLayout(m2);
 	}
 	
 	/**
@@ -527,6 +567,23 @@ public interface PersistenceTypeDescriptionMember
 	)
 	{
 		return equalMembers(members1, members2, PersistenceTypeDescriptionMember::equalStructure);
+	}
+
+	/**
+	 * Pairwise compares two member sequences using
+	 * {@link #equalLayout(PersistenceTypeDescriptionMember, PersistenceTypeDescriptionMember)}.
+	 *
+	 * @param members1 the first sequence.
+	 * @param members2 the second sequence.
+	 *
+	 * @return {@code true} if the sequences are pairwise equal in persistent layout.
+	 */
+	public static boolean equalLayouts(
+		final XGettingSequence<? extends PersistenceTypeDescriptionMember> members1,
+		final XGettingSequence<? extends PersistenceTypeDescriptionMember> members2
+	)
+	{
+		return equalMembers(members1, members2, PersistenceTypeDescriptionMember::equalLayout);
 	}
 
 	/**

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceTypeDescriptionMemberEnumConstant.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceTypeDescriptionMemberEnumConstant.java
@@ -49,6 +49,15 @@ public interface PersistenceTypeDescriptionMemberEnumConstant extends Persistenc
 			&& equalName(this, (PersistenceTypeDescriptionMemberEnumConstant)other)
 		;
 	}
+
+	@Override
+	public default boolean equalsLayout(final PersistenceTypeDescriptionMember other)
+	{
+		// enum-constant entries have no layout footprint (length 0); identity lives in name().
+		// Callers that pair members by mapping/order already establish identity correspondence,
+		// so layout equality here only confirms both members are enum-constant entries.
+		return other instanceof PersistenceTypeDescriptionMemberEnumConstant;
+	}
 	
 	@Override
 	public default boolean equalsDescription(final PersistenceTypeDescriptionMember member)

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceTypeDescriptionMemberFieldGenericComplex.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceTypeDescriptionMemberFieldGenericComplex.java
@@ -71,6 +71,18 @@ extends PersistenceTypeDescriptionMemberFieldGenericVariableLength
 			)
 		;
 	}
+
+	@Override
+	public default boolean equalsLayout(final PersistenceTypeDescriptionMember other)
+	{
+		return PersistenceTypeDescriptionMemberFieldGenericVariableLength.super.equalsLayout(other)
+			&& other instanceof PersistenceTypeDescriptionMemberFieldGenericComplex
+			&& PersistenceTypeDescriptionMember.equalLayouts(
+				this.members(),
+				((PersistenceTypeDescriptionMemberFieldGenericComplex)other).members()
+			)
+		;
+	}
 	
 	/**
 	 * Type-specific overload of

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceTypeDescriptionMemberFieldGenericVariableLength.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceTypeDescriptionMemberFieldGenericVariableLength.java
@@ -47,6 +47,15 @@ extends PersistenceTypeDescriptionMemberFieldGeneric
 			&& PersistenceTypeDescriptionMemberFieldGeneric.super.equalsStructure(other)
 		;
 	}
+
+	@Override
+	public default boolean equalsLayout(final PersistenceTypeDescriptionMember other)
+	{
+		// the type check is the only specific thing here.
+		return other instanceof PersistenceTypeDescriptionMemberFieldGenericVariableLength
+			&& PersistenceTypeDescriptionMemberFieldGeneric.super.equalsLayout(other)
+		;
+	}
 	
 	/**
 	 * Type-specific overload of

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceTypeDescriptionMemberPrimitiveDefinition.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceTypeDescriptionMemberPrimitiveDefinition.java
@@ -65,6 +65,18 @@ public interface PersistenceTypeDescriptionMemberPrimitiveDefinition extends Per
 			&& equalDescription(this, (PersistenceTypeDescriptionMemberPrimitiveDefinition)member)
 		;
 	}
+
+	@Override
+	public default boolean equalsLayout(final PersistenceTypeDescriptionMember other)
+	{
+		// primitive-definition members carry a null typeName; identity lives in primitiveDefinition().
+		return other instanceof PersistenceTypeDescriptionMemberPrimitiveDefinition
+			&& Objects.equals(
+				this.primitiveDefinition(),
+				((PersistenceTypeDescriptionMemberPrimitiveDefinition)other).primitiveDefinition()
+			)
+		;
+	}
 	
 	/**
 	 * Tests whether two primitive-definition entries record the same {@link #primitiveDefinition()}


### PR DESCRIPTION
## Summary
- `PersistenceLegacyTypeMappingResult.isUnchangedStructure` compared `mapping.get(legacyMember)` — a `Similarity<PersistenceTypeDefinitionMember>` — directly against `currentMember` via `!=`. The two are unrelated types, so the check was always true and the method always returned `false` on the first iteration.
- The unchanged-structure fast path in `PersistenceLegacyTypeHandlerCreator` therefore never fired: every legacy handler went through the translating path even when the persisted layout was actually unchanged, producing more expensive handlers than necessary on load.
- Fix: extract `targetElement()` from the similarity (with a null guard) before comparing — same pattern already used in `PersistenceLegacyTypeHandlerCreator.deriveEnumOrdinalMapping`.
