### PR TITLE
Fix type dictionary provider listener wiring

### DIFF
--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceTypeDictionaryFileHandler.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceTypeDictionaryFileHandler.java
@@ -380,7 +380,7 @@ public class PersistenceTypeDictionaryFileHandler implements PersistenceTypeDict
 			final PersistenceTypeDictionaryStorer writeListener
 		)
 		{
-			return PersistenceTypeDictionaryFileHandler.New(this.file);
+			return PersistenceTypeDictionaryFileHandler.New(this.file, writeListener);
 		}
 		
 	}


### PR DESCRIPTION
PersistenceTypeDictionaryFileHandler.Provider: thread writeListener through to New(file, writeListener) instead of dropping it