### PR TITLE
chore: update GitHub Actions versions in CI workflows

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -17,9 +17,9 @@ jobs:
 
     steps:
       #Build with java 17
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -5,7 +5,7 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: 
+    branches:
       - '**'
   pull_request:
     branches: [ main ]
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       #Build with java 17
-    - uses: actions/checkout@v6
-    - name: Set up JDK 17
-      uses: actions/setup-java@v5
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: 'maven'
-    - name: Build with Maven
-      run: mvn -B clean package --file pom.xml
+      - uses: actions/checkout@v6
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Build with Maven
+        run: mvn -B clean package --file pom.xml

--- a/.github/workflows/maven_build_25.yml
+++ b/.github/workflows/maven_build_25.yml
@@ -5,7 +5,7 @@ name: Java CI 25 with Maven
 
 on:
   push:
-    branches: 
+    branches:
       - '**'
   pull_request:
     branches: [ main ]
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       #Build with java 25
-    - uses: actions/checkout@v6
-    - name: Set up JDK 25
-      uses: actions/setup-java@v5
-      with:
-        java-version: '25'
-        distribution: 'temurin'
-        cache: 'maven'
-    - name: Build with Maven
-      run: mvn -B clean package --file pom.xml
+      - uses: actions/checkout@v6
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Build with Maven
+        run: mvn -B clean package --file pom.xml

--- a/.github/workflows/maven_build_25.yml
+++ b/.github/workflows/maven_build_25.yml
@@ -17,9 +17,9 @@ jobs:
 
     steps:
       #Build with java 25
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up JDK 25
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         java-version: '25'
         distribution: 'temurin'

--- a/.github/workflows/maven_build_win.yml
+++ b/.github/workflows/maven_build_win.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/maven_deploy_snapshot.yml
+++ b/.github/workflows/maven_deploy_snapshot.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-native
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Java 25 for publishing
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -31,7 +31,7 @@ jobs:
           server-password: MAVEN_PASSWORD
 
       - name: Download all native artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: nativememory/target/libs
           merge-multiple: 'true'

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-native
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Java 25 for publishing
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -28,7 +28,7 @@ jobs:
           server-password: MAVEN_PASSWORD
 
       - name: Download all native artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: nativememory/target/libs
           merge-multiple: 'true'

--- a/.github/workflows/maven_javadoc.yml
+++ b/.github/workflows/maven_javadoc.yml
@@ -17,9 +17,9 @@ jobs:
 
     steps:
       #Build with java 17
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/maven_javadoc.yml
+++ b/.github/workflows/maven_javadoc.yml
@@ -5,7 +5,7 @@ name: Java JavaDoc check
 
 on:
   push:
-    branches: 
+    branches:
       - '**'
   pull_request:
     branches: [ main ]
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       #Build with java 17
-    - uses: actions/checkout@v6
-    - name: Set up JDK 17
-      uses: actions/setup-java@v5
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: 'maven'
-    - name: Build with Maven
-      run: mvn -P javadoc-check -B clean package --file pom.xml
+      - uses: actions/checkout@v6
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Build with Maven
+        run: mvn -P javadoc-check -B clean package --file pom.xml

--- a/.github/workflows/maven_jni_25.yml
+++ b/.github/workflows/maven_jni_25.yml
@@ -73,9 +73,9 @@ jobs:
               cp ../target/libs/libEclipseStoreNativeMemory.dylib ../libEclipseStoreNativeMemory-macos-arm64.dylib
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: temurin
@@ -88,7 +88,7 @@ jobs:
         run: ${{ matrix.build-cmd }}
 
       - name: Upload native library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-${{ matrix.os }}-${{ matrix.arch }}
           path: nativememory/libEclipseStoreNativeMemory-*.${{ matrix.ext }}

--- a/.github/workflows/maven_licence_check.yml
+++ b/.github/workflows/maven_licence_check.yml
@@ -17,9 +17,9 @@ jobs:
 
     steps:
       #Build with java 17
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/maven_licence_check.yml
+++ b/.github/workflows/maven_licence_check.yml
@@ -5,7 +5,7 @@ name: Licence header check
 
 on:
   push:
-    branches: 
+    branches:
       - '**'
   pull_request:
     branches: [ main ]
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       #Build with java 17
-    - uses: actions/checkout@v6
-    - name: Set up JDK 17
-      uses: actions/setup-java@v5
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: 'maven'
-    - name: Build with Maven
-      run: mvn -B clean license:check-file-header --file pom.xml
+      - uses: actions/checkout@v6
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Build with Maven
+        run: mvn -B clean license:check-file-header --file pom.xml

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-native
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Java 25 for publishing
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -28,7 +28,7 @@ jobs:
           server-password: MAVEN_PASSWORD
 
       - name: Download all native artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: nativememory/target/libs
           merge-multiple: 'true'


### PR DESCRIPTION
This pull request updates the versions of several GitHub Actions used in the project's workflow YAML files. The main goal is to ensure that the CI/CD pipelines use the latest and most secure versions of these actions, which can bring performance improvements, new features, and security fixes.

**GitHub Actions version upgrades:**

*General workflow improvements:*
- Updated all occurrences of `actions/checkout` to version `v6` across all workflow files. [[1]](diffhunk://#diff-5e9df5c7ba9a0e12d454053f62cec530d95c52e2dc4a4f1e6755b6499686d764L20-R22) [[2]](diffhunk://#diff-9c9c624593b8e7c1210c9b080f3f5711ea3add074088d9aababa5d8ad6fdb830L20-R22) [[3]](diffhunk://#diff-e77b56b9896f79686ebc79a8aa2f9a3504f3a42badbb6f53e667642a68fa6259L18-R20) [[4]](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L21-R24) [[5]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L18-R21) [[6]](diffhunk://#diff-013a2ec5c7db633eb7cfe5ed77d6536fed02843f4d5c253f059e2728751b3e16L20-R22) [[7]](diffhunk://#diff-9a13dd3eee27bc354887248e512cad3f526b5a140c25f04090d9f63e452253c0L76-R78) [[8]](diffhunk://#diff-64392646b49a1d14736c149a4698977a54bfb6c569f9f623ca6cd4c3d1658c95L20-R22) [[9]](diffhunk://#diff-81f8c014d70e0efb7dd886d9353bd9f2d694907253e3abdfa029f9cdb3c9fba1L18-R21)
- Updated all occurrences of `actions/setup-java` to version `v5` across all workflow files. [[1]](diffhunk://#diff-5e9df5c7ba9a0e12d454053f62cec530d95c52e2dc4a4f1e6755b6499686d764L20-R22) [[2]](diffhunk://#diff-9c9c624593b8e7c1210c9b080f3f5711ea3add074088d9aababa5d8ad6fdb830L20-R22) [[3]](diffhunk://#diff-e77b56b9896f79686ebc79a8aa2f9a3504f3a42badbb6f53e667642a68fa6259L18-R20) [[4]](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L21-R24) [[5]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L18-R21) [[6]](diffhunk://#diff-013a2ec5c7db633eb7cfe5ed77d6536fed02843f4d5c253f059e2728751b3e16L20-R22) [[7]](diffhunk://#diff-9a13dd3eee27bc354887248e512cad3f526b5a140c25f04090d9f63e452253c0L76-R78) [[8]](diffhunk://#diff-64392646b49a1d14736c149a4698977a54bfb6c569f9f623ca6cd4c3d1658c95L20-R22) [[9]](diffhunk://#diff-81f8c014d70e0efb7dd886d9353bd9f2d694907253e3abdfa029f9cdb3c9fba1L18-R21)

*Artifact management improvements:*
- Updated `actions/download-artifact` from `v4` to `v8` in deployment workflow files for downloading native artifacts. [[1]](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L34-R34) [[2]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L31-R31)
- Updated `actions/upload-artifact` from `v4` to `v7` in the JNI build workflow for uploading native libraries.

These updates help keep our CI/CD workflows current and secure, reducing the risk of using outdated or deprecated actions.