### PR TITLE
update plugin versions in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>license-maven-plugin</artifactId>
-					<version>2.4.0</version>
+					<version>2.7.1</version>
 					<configuration>
 						<includes>
 							<include>**/*.java</include>
@@ -243,7 +243,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-gpg-plugin</artifactId>
-					<version>3.2.6</version>
+					<version>3.2.8</version>
 					<executions>
 						<execution>
 							<id>sign-artifacts</id>
@@ -265,12 +265,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-deploy-plugin</artifactId>
-					<version>3.1.3</version>
+					<version>3.1.4</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-enforcer-plugin</artifactId>
-					<version>3.5.0</version>
+					<version>3.6.2</version>
 					<executions>
 						<execution>
 							<id>enforce-env</id>
@@ -294,17 +294,17 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-clean-plugin</artifactId>
-					<version>3.4.0</version>
+					<version>3.5.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>3.3.1</version>
+					<version>3.4.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-install-plugin</artifactId>
-					<version>3.1.3</version>
+					<version>3.1.4</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -314,12 +314,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.6.0</version>
+					<version>3.6.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.sonatype.central</groupId>
 					<artifactId>central-publishing-maven-plugin</artifactId>
-					<version>0.8.0</version>
+					<version>0.10.0</version>
 					<extensions>true</extensions>
 					<configuration>
 						<publishingServerId>central</publishingServerId>


### PR DESCRIPTION
This pull request updates several Maven plugin versions in the `pom.xml` file to keep the build process up-to-date and benefit from the latest fixes and improvements. No other functional or code changes are included.

Dependency and build tool updates:

* Updated the following Maven plugins to newer versions for improved stability and compatibility:
  - `license-maven-plugin` to 2.7.1
  - `maven-gpg-plugin` to 3.2.8
  - `maven-deploy-plugin` to 3.1.4
  - `maven-enforcer-plugin` to 3.6.2
  - `maven-clean-plugin` to 3.5.0
  - `maven-resources-plugin` to 3.4.0
  - `maven-install-plugin` to 3.1.4
  - `maven-shade-plugin` to 3.6.1
  - `central-publishing-maven-plugin` to 0.10.0