### PR TITLE
Chore/pom best practices

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>license-maven-plugin</artifactId>
-					<version>2.4.0</version>
+					<version>2.7.1</version>
 					<configuration>
 						<includes>
 							<include>**/*.java</include>
@@ -243,7 +243,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-gpg-plugin</artifactId>
-					<version>3.2.6</version>
+					<version>3.2.8</version>
 					<executions>
 						<execution>
 							<id>sign-artifacts</id>
@@ -265,12 +265,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-deploy-plugin</artifactId>
-					<version>3.1.3</version>
+					<version>3.1.4</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-enforcer-plugin</artifactId>
-					<version>3.5.0</version>
+					<version>3.6.2</version>
 					<executions>
 						<execution>
 							<id>enforce-env</id>
@@ -294,17 +294,17 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-clean-plugin</artifactId>
-					<version>3.4.0</version>
+					<version>3.5.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>3.3.1</version>
+					<version>3.4.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-install-plugin</artifactId>
-					<version>3.1.3</version>
+					<version>3.1.4</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -314,12 +314,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.6.0</version>
+					<version>3.6.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.sonatype.central</groupId>
 					<artifactId>central-publishing-maven-plugin</artifactId>
-					<version>0.8.0</version>
+					<version>0.10.0</version>
 					<extensions>true</extensions>
 					<configuration>
 						<publishingServerId>central</publishingServerId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
 		<license.licenceFile>${basedir}/LICENSE</license.licenceFile>
 		<api.version>1</api.version>
 		<javadoc.failed.on.error>false</javadoc.failed.on.error>
-		<failsafe.rerunFailingTestsCount>2</failsafe.rerunFailingTestsCount>
 		<surefire.rerunFailingTestsCount>2</surefire.rerunFailingTestsCount>
 		<slf4j.version>2.0.17</slf4j.version>
 	</properties>
@@ -305,6 +304,11 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-install-plugin</artifactId>
 					<version>3.1.4</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>3.5.5</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This pull request makes updates to the project's Maven configuration, specifically related to test execution plugins. The main changes involve updating the configuration for test retries and explicitly adding a newer version of the Surefire plugin.

**Maven test plugin configuration:**

* Removed the `failsafe.rerunFailingTestsCount` property from the root properties, which previously controlled the number of retries for failing integration tests.
* Explicitly added the `maven-surefire-plugin` version 3.5.5 to the build plugins, ensuring the use of a specific, up-to-date version for running unit tests.