### PR TITLE
Update upload-artifact action to version 7 in SBOM generation workflow

### DIFF
--- a/.github/workflows/generate-maven-sbom.yml
+++ b/.github/workflows/generate-maven-sbom.yml
@@ -57,7 +57,7 @@ jobs:
               -DoutputDirectory=target/sbom
 
       - name: Upload
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@v7
         with:
           name: sbom
           path: target/sbom/Eclipse-Serializer-Sbom.json


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the `actions/upload-artifact` action. This change helps ensure compatibility and access to the latest features and fixes.

Dependency and workflow updates:

* Updated the `actions/upload-artifact` action from a specific commit hash (v4.6.2) to the latest major version (`v7`) in the `.github/workflows/generate-maven-sbom.yml` workflow file.