### PR TITLE
Add validation and bounded read timeout to ComBinaryDynamic type-mapping handshake

### DIFF
--- a/communication/binary/src/main/java/org/eclipse/serializer/communication/binarydynamic/ComTypeMappingResolver.java
+++ b/communication/binary/src/main/java/org/eclipse/serializer/communication/binarydynamic/ComTypeMappingResolver.java
@@ -111,21 +111,21 @@ public class ComTypeMappingResolver
 	////////////
 	
 	/**
-	 * Handle the client's side of the communication type mapping during connection initialization phase.
-	 * This is collection all type definition that belong to the clients classes that needs to be mapped by the host
+	 * Handle the client's side of the communication type mapping during the connection initialization phase.
+	 * This is a collection of all type definitions that belong to the client classes that need to be mapped by the host
 	 * and transferring those to the host.
 	 */
 	public void resolveClient()
 	{
 		logger.debug("resolving client type mappings ");
 		
-		this.sendNewTypeDefintionsToHost(
+		this.sendNewTypeDefinitionsToHost(
 			this.assembleTypeDefinitions(
 				this.findHostTypeDefinitions()));
 	}
 	
 	/**
-	 * Handle the host's side of the communication type mapping during connection initialization phase.
+	 * Handle the host's side of the communication type mapping during the connection initialization phase.
 	 * This is receiving the client's type definitions and creating the required legacy type handlers.
 	 */
 	public void resolveHost()
@@ -134,12 +134,12 @@ public class ComTypeMappingResolver
 		
 		this.applyHostTypeMapping(
 			this.parseClientTypeDefinitions(
-				this.receiveUpdatedDefintionsfromClient()));
+				this.receiveUpdatedDefinitionsFromClient()));
 	}
 	
-	private void sendNewTypeDefintionsToHost(final byte[] assembledTypeDefinitions)
+	private void sendNewTypeDefinitionsToHost(final byte[] assembledTypeDefinitions)
 	{
-		logger.trace("transfering new type defintions to host");
+		logger.trace("transferring new type definitions to host");
 		
 		final ByteBuffer dbb = XMemory.allocateDirectNative(assembledTypeDefinitions.length);
 		final long dbbAddress = XMemory.getDirectByteBufferAddress(dbb);
@@ -158,7 +158,7 @@ public class ComTypeMappingResolver
 		.add(String.format("%08d", newDefinitions.intSize()));
 		
 		newDefinitions.forEach(definition -> {
-			vs.add(this.assembleTypeDefintion(definition));
+			vs.add(this.assembleTypeDefinition(definition));
 		});
 		
 		final char[] lengthString = XChars.readChars(XChars.String(vs.length()));
@@ -167,7 +167,7 @@ public class ComTypeMappingResolver
 		return vs.encode();
 	}
 
-	private VarString assembleTypeDefintion(final PersistenceTypeDescription definition)
+	private VarString assembleTypeDefinition(final PersistenceTypeDescription definition)
 	{
 		final VarString vc = VarString.New();
 		this.typeDictionaryAssembler.assembleTypeDescription(vc, definition);
@@ -198,8 +198,8 @@ public class ComTypeMappingResolver
 			buffer.position(1);
 			final char[] typeDefinitionsChars = XChars.standardCharset().decode(buffer).array();
 		
-			final String typeDefintions = XChars.String(typeDefinitionsChars);
-			final XGettingSequence<PersistenceTypeDefinition> newTypeDescriptions = this.typeDefinitionBuilder.buildTypeDefinitions(typeDefintions);
+			final String typeDefinitions = XChars.String(typeDefinitionsChars);
+			final XGettingSequence<PersistenceTypeDefinition> newTypeDescriptions = this.typeDefinitionBuilder.buildTypeDefinitions(typeDefinitions);
 			
 			logger.debug("received {} types from client", newTypeDescriptions.size());
 			return newTypeDescriptions;
@@ -209,16 +209,16 @@ public class ComTypeMappingResolver
 		return BulkList.New();
 	}
 
-	private ByteBuffer receiveUpdatedDefintionsfromClient()
+	private ByteBuffer receiveUpdatedDefinitionsFromClient()
 	{
-		logger.trace("receiving new type defintions from client");
+		logger.trace("receiving new type definitions from client");
 
 		final int length = this.readHeaderField("length");
 		final int count  = this.readHeaderField("count");
 
 		this.validateTypeMappingHeader(length, count);
 
-		if(count > 0 )
+		if(count > 0)
 		{
 			final int bodyLength = length - LENGTH_CHAR_COUNT - LENGTH_CHAR_COUNT;
 			final ByteBuffer typeDefinitionsBuffer = XMemory.allocateDirectNative(bodyLength);
@@ -282,7 +282,7 @@ public class ComTypeMappingResolver
 		/*
 		 * The declared type count and body length must be consistent: zero types means an empty
 		 * body (length == header size), and every declared type definition requires at least one
-		 * body byte. Otherwise a declared-but-unconsumed body would be left in the stream and
+		 * body byte. Otherwise, a declared-but-unconsumed body would be left in the stream and
 		 * desynchronize the channel (only the body is read when count > 0, see below).
 		 */
 		final int bodyLength = length - LENGTH_CHAR_COUNT - LENGTH_CHAR_COUNT;

--- a/communication/binary/src/main/java/org/eclipse/serializer/communication/binarydynamic/ComTypeMappingResolver.java
+++ b/communication/binary/src/main/java/org/eclipse/serializer/communication/binarydynamic/ComTypeMappingResolver.java
@@ -20,6 +20,7 @@ import org.eclipse.serializer.chars.VarString;
 import org.eclipse.serializer.chars.XChars;
 import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.collections.types.XGettingSequence;
+import org.eclipse.serializer.com.ComException;
 import org.eclipse.serializer.communication.types.ComConnection;
 import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.serializer.persistence.binary.types.Binary;
@@ -44,6 +45,22 @@ public class ComTypeMappingResolver
 	//////////////
 	
 	protected static final int LENGTH_CHAR_COUNT = 8;
+
+	/*
+	 * Hardening limits for the dynamic type-mapping handshake. The host reads the length and count
+	 * header fields from an unauthenticated peer and would otherwise allocate a direct buffer of the
+	 * declared size before validating anything (CWE-770 / CWE-400). These bounds reject malformed,
+	 * negative-sized and excessively large messages before any allocation takes place.
+	 */
+
+	// the two header fields (length + count) are the minimum a well-formed message can contain
+	protected static final int MIN_MESSAGE_LENGTH = LENGTH_CHAR_COUNT + LENGTH_CHAR_COUNT;
+
+	// generous upper bound on a single type-mapping message; far larger than any realistic type dictionary
+	protected static final int MAX_MESSAGE_LENGTH = 64 * 1024 * 1024;
+
+	// upper bound on the number of declared type definitions in a single message
+	protected static final int MAX_TYPE_COUNT     = 1_000_000;
 		
 	private final static Logger logger = Logging.getLogger(ComHandlerSendMessageNewType.class);
 	
@@ -195,28 +212,80 @@ public class ComTypeMappingResolver
 	private ByteBuffer receiveUpdatedDefintionsfromClient()
 	{
 		logger.trace("receiving new type defintions from client");
-		
-		final ByteBuffer lengthBuffer = XMemory.allocateDirectNative(LENGTH_CHAR_COUNT);
-		this.connection.read(lengthBuffer, LENGTH_CHAR_COUNT);
-		
-		lengthBuffer.position(0);
-		final String lengthDigits = XChars.standardCharset().decode(lengthBuffer).toString();
-		final int    length       = Integer.parseInt(lengthDigits);
-		
-		final ByteBuffer countBuffer = XMemory.allocateDirectNative(LENGTH_CHAR_COUNT);
-		this.connection.read(countBuffer, LENGTH_CHAR_COUNT);
-		countBuffer.position(0);
-		final String countDigits = XChars.standardCharset().decode(countBuffer).toString();
-		final int    count       = Integer.parseInt(countDigits);
-		
+
+		final int length = this.readHeaderField("length");
+		final int count  = this.readHeaderField("count");
+
+		this.validateTypeMappingHeader(length, count);
+
 		if(count > 0 )
 		{
-			final ByteBuffer typeDefinitionsBuffer = XMemory.allocateDirectNative(length - LENGTH_CHAR_COUNT - LENGTH_CHAR_COUNT);
-			this.connection.read(typeDefinitionsBuffer, length - LENGTH_CHAR_COUNT - LENGTH_CHAR_COUNT);
+			final int bodyLength = length - LENGTH_CHAR_COUNT - LENGTH_CHAR_COUNT;
+			final ByteBuffer typeDefinitionsBuffer = XMemory.allocateDirectNative(bodyLength);
+			this.connection.read(typeDefinitionsBuffer, bodyLength);
 			return typeDefinitionsBuffer;
 		}
-		
+
 		return null;
+	}
+
+	/**
+	 * Reads a single fixed-width {@link #LENGTH_CHAR_COUNT}-character ASCII decimal header field
+	 * and parses it. The decoded characters are verified to be decimal digits before parsing so
+	 * that malformed (non-numeric or signed) handshake data is rejected with a clear
+	 * {@link ComException} instead of relying on {@link NumberFormatException} or producing a
+	 * negative value.
+	 */
+	private int readHeaderField(final String fieldName)
+	{
+		final ByteBuffer buffer = XMemory.allocateDirectNative(LENGTH_CHAR_COUNT);
+		this.connection.read(buffer, LENGTH_CHAR_COUNT);
+
+		buffer.position(0);
+		final String digits = XChars.standardCharset().decode(buffer).toString();
+
+		for(int i = 0; i < digits.length(); i++)
+		{
+			final char c = digits.charAt(i);
+			if(c < '0' || c > '9')
+			{
+				throw new ComException("Invalid type mapping " + fieldName + " field: non-numeric handshake data");
+			}
+		}
+
+		return Integer.parseInt(digits);
+	}
+
+	/**
+	 * Validates the type-mapping message header before any body buffer is allocated. Guards against
+	 * negative-sized allocations (length below the header size), excessively large allocations
+	 * (length above {@link #MAX_MESSAGE_LENGTH}) and inconsistent or oversized type counts.
+	 */
+	private void validateTypeMappingHeader(final int length, final int count)
+	{
+		if(length < MIN_MESSAGE_LENGTH)
+		{
+			throw new ComException("Type mapping message length " + length
+				+ " is below the minimum of " + MIN_MESSAGE_LENGTH);
+		}
+		if(length > MAX_MESSAGE_LENGTH)
+		{
+			throw new ComException("Type mapping message length " + length
+				+ " exceeds the maximum of " + MAX_MESSAGE_LENGTH);
+		}
+		if(count > MAX_TYPE_COUNT)
+		{
+			throw new ComException("Type mapping type count " + count
+				+ " exceeds the maximum of " + MAX_TYPE_COUNT);
+		}
+
+		// every declared type definition requires at least one body byte; reject inconsistent headers
+		final int bodyLength = length - LENGTH_CHAR_COUNT - LENGTH_CHAR_COUNT;
+		if(count > bodyLength)
+		{
+			throw new ComException("Type mapping type count " + count
+				+ " is inconsistent with the declared body length " + bodyLength);
+		}
 	}
 	
 	private void applyHostTypeMapping(final XGettingSequence<PersistenceTypeDefinition> typeDefinitions)

--- a/communication/binary/src/main/java/org/eclipse/serializer/communication/binarydynamic/ComTypeMappingResolver.java
+++ b/communication/binary/src/main/java/org/eclipse/serializer/communication/binarydynamic/ComTypeMappingResolver.java
@@ -279,9 +279,14 @@ public class ComTypeMappingResolver
 				+ " exceeds the maximum of " + MAX_TYPE_COUNT);
 		}
 
-		// every declared type definition requires at least one body byte; reject inconsistent headers
+		/*
+		 * The declared type count and body length must be consistent: zero types means an empty
+		 * body (length == header size), and every declared type definition requires at least one
+		 * body byte. Otherwise a declared-but-unconsumed body would be left in the stream and
+		 * desynchronize the channel (only the body is read when count > 0, see below).
+		 */
 		final int bodyLength = length - LENGTH_CHAR_COUNT - LENGTH_CHAR_COUNT;
-		if(count > bodyLength)
+		if(count == 0 ? bodyLength != 0 : count > bodyLength)
 		{
 			throw new ComException("Type mapping type count " + count
 				+ " is inconsistent with the declared body length " + bodyLength);

--- a/communication/communication/src/main/java/org/eclipse/serializer/communication/types/ComConnectionAcceptor.java
+++ b/communication/communication/src/main/java/org/eclipse/serializer/communication/types/ComConnectionAcceptor.java
@@ -132,12 +132,19 @@ public interface ComConnectionAcceptor<C>
 				this.connectionHandler.enableSecurity(connection);
 				
 				final ComProtocol protocol = this.protocolProvider.provideProtocol(connection);
-				this.connectionHandler.setInactivityTimeout(connection, protocol.inactivityTimeout());
 								
 				this.connectionHandler.sendProtocol(connection, protocol, this.protocolStringConverter);
 				
+				// The dynamic type-mapping handshake runs inside createHostChannel and reads
+				// attacker-controlled data from an as-yet-unauthenticated peer. It must therefore stay
+				// bounded by the connection's (positive) handshake read timeout. The configured
+				// inactivity timeout - which may be 0 (= wait indefinitely for client messages) - is
+				// applied only afterwards, once the connection has become an established channel, so it
+				// can no longer disable the read deadline during the handshake.
 				final ComHostChannel<C> channel = this.persistenceAdaptor.createHostChannel(connection, protocol, parent);
-				
+
+				this.connectionHandler.setInactivityTimeout(connection, protocol.inactivityTimeout());
+
 				try
 				{
 					this.channelAcceptor.acceptChannel(channel);


### PR DESCRIPTION
Hardens the `ComBinaryDynamic` host handshake by validating the dynamic type-mapping header before allocating buffers and by keeping the handshake reads bounded by a read timeout.

## Changes

**`ComTypeMappingResolver`**
- Validate the type-mapping header before allocating the body buffer: numeric field parsing with explicit checks, plus minimum/maximum message length, a out-of-range headers are rejected with a `ComException`.

**`ComConnectionAcceptor`**
- Apply the inactivity timeout only after the channel is established, so the handshake reads remain bounded by the connection's handshake read timeout instead of an inactivity value that may be `0` (infinite).

## Testing

- Malformed, oversized, and negative-length headers are rejected before any buffer allocation.
- A stalled handshake now times out instead of blocking connection acceptance.
- A normal client still completes the handshake and round-trips a message (no regression).