### PR TITLE
Pin lazily-skipped instances in BinaryStorer until commit

### DIFF
--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
@@ -657,7 +657,13 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			{
 				for(Item e = this.hashSlots[identityHashCode(object) & this.hashRange]; e != null; e = e.link)
 				{
-					if(e.instance == object)
+					/*
+					 * Pin items are pure GC-protection entries for skipped referents and must be invisible
+					 * here: a lookup hit means "this storer already handled the instance", which would make
+					 * explicit stores (internalStore) and eager applies silently no-ops for merely
+					 * referenced instances.
+					 */
+					if(e.instance == object && !isPinItem(e))
 					{
 						return e.oid;
 					}
@@ -667,10 +673,15 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				return Swizzling.notFoundId();
 			}
 		}
-		
+
 		private static boolean isSkipItem(final Item item)
 		{
 			return item.typeHandler == null;
+		}
+
+		private static boolean isPinItem(final Item item)
+		{
+			return item instanceof PinItem;
 		}
 		
 		@Override
@@ -751,7 +762,52 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		{
 			// default is lazy logic, so no-op
 		}
-		
+
+		@Override
+		public <T> void registerSkippedOptional(
+			final long                              objectId       ,
+			final T                                 instance       ,
+			final PersistenceTypeHandler<Binary, T> optionalHandler
+		)
+		{
+			/*
+			 * Pin the skipped referent: its objectId gets written into this storer's chunk, but since the
+			 * instance is already globally known, no Item would be created and this storer would hold no
+			 * strong reference to it. If the application drops its last strong reference between store and
+			 * commit, the object registry's weak entry gets reaped and the storage GC deletes the entity
+			 * while the chunk referencing it is not yet committed - the commit would then persist a
+			 * dangling reference (missing entity on later loads).
+			 * A PinItem holds the instance strongly until commit()/clear(), keeping its object registry
+			 * entry populated so the GC's live-objectId safety net protects the entity. Pin items are
+			 * never part of the item chain (not serialized, not merged) and are invisible to lookupOid,
+			 * so explicit stores and eager applies of the instance still get processed normally.
+			 */
+			synchronized(this.objectRegistryMonitor)
+			{
+				// any existing local entry (regular, skip or pin) already holds the instance strongly
+				for(Item e = this.hashSlots[identityHashCode(instance) & this.hashRange]; e != null; e = e.link)
+				{
+					if(e.instance == instance)
+					{
+						return;
+					}
+				}
+
+				if(++this.itemCount >= this.hashRange)
+				{
+					this.synchRebuildStoreItems();
+				}
+
+				this.hashSlots[identityHashCode(instance) & this.hashRange] =
+					new PinItem(
+						instance,
+						objectId,
+						this.hashSlots[identityHashCode(instance) & this.hashRange]
+					)
+				;
+			}
+		}
+
 		protected final long register(final Object instance)
 		{
 			/* Note:
@@ -1419,7 +1475,7 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		}
 	}
 
-	static final class Item
+	static class Item
 	{
 		final PersistenceTypeHandler<Binary, Object> typeHandler;
 		final Object                                 instance   ;
@@ -1438,6 +1494,22 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			this.oid         = oid        ;
 			this.typeHandler = typeHandler;
 			this.link        = link       ;
+		}
+
+	}
+
+	/**
+	 * Pure pin entry for a skipped referent (see {@code Default#registerSkippedOptional}): holds the
+	 * instance strongly until commit/clear so the storage GC cannot delete the referenced entity while
+	 * the chunk referencing it is not yet committed. Never part of the item chain (not serialized, not
+	 * merged) and invisible to {@code lookupOid}, so explicit stores and eager applies still process
+	 * the instance normally.
+	 */
+	static final class PinItem extends Item
+	{
+		PinItem(final Object instance, final long oid, final Item link)
+		{
+			super(instance, oid, null, link);
 		}
 
 	}

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
@@ -732,10 +732,18 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 						 * happen to satisfy as well (null typeHandler): semantically, a skip is a
 						 * user assertion while a pin is a retention entry - a future change to
 						 * either criterion must not silently expose pins to peer storers here.
+						 * A pin is ignored but must NOT terminate the search: a hash rebuild reverses
+						 * the slot chain order, so a pin can precede a regular item for the same
+						 * instance (lazy skip pinned it, a later explicit store created the item) -
+						 * that item's association must still be offered to the receiver.
 						 */
-						if(isPinItem(e) || isSkipItem(e))
+						if(isPinItem(e))
 						{
-							// local-only entry for this storer, so it can offer nothing to the receiver.
+							continue;
+						}
+						if(isSkipItem(e))
+						{
+							// skip-entry for this storer, so it can offer nothing to the receiver.
 							break;
 						}
 

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
@@ -368,40 +368,40 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		@Override
 		public <T> long apply(final T instance)
 		{
-			// concurrency: lookupOid() and ensureObjectId() lock internally, the rest is thread-local
-			
+			// concurrency: lookupOidLazyApplicable() and ensureObjectId() lock internally, the rest is thread-local
+
 			if(instance == null)
 			{
 				return Swizzling.nullId();
 			}
-			
+
 			final long objectIdLocal;
-			if(Swizzling.isFoundId(objectIdLocal = this.lookupOid(instance)))
+			if(Swizzling.isFoundId(objectIdLocal = this.lookupOidLazyApplicable(instance)))
 			{
 				// returning 0 is a valid case: an instance registered to be skipped by using the null-OID.
 				return objectIdLocal;
 			}
-			
+
 			return this.register(instance);
 		}
-		
+
 		@Override
 		public <T> long apply(final T instance, final PersistenceTypeHandler<Binary, T> localTypeHandler)
 		{
-			// concurrency: lookupOid() and ensureObjectId() lock internally, the rest is thread-local
-			
+			// concurrency: lookupOidLazyApplicable() and ensureObjectId() lock internally, the rest is thread-local
+
 			if(instance == null)
 			{
 				return Swizzling.nullId();
 			}
-			
+
 			final long objectIdLocal;
-			if(Swizzling.isFoundId(objectIdLocal = this.lookupOid(instance)))
+			if(Swizzling.isFoundId(objectIdLocal = this.lookupOidLazyApplicable(instance)))
 			{
 				// returning 0 is a valid case: an instance registered to be skipped by using the null-OID.
 				return objectIdLocal;
 			}
-			
+
 			return this.objectManager.ensureObjectId(instance, this, localTypeHandler);
 		}
 		
@@ -653,17 +653,39 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		
 		public final long lookupOid(final Object object)
 		{
+			/*
+			 * Pin items are pure GC-protection entries for skipped referents and must be invisible
+			 * here: a lookup hit means "this storer already handled the instance", which would make
+			 * explicit stores (internalStore) and eager applies silently no-ops for merely
+			 * referenced instances.
+			 */
+			return this.lookupOid(object, false);
+		}
+
+		/**
+		 * Variant of {@link #lookupOid(Object)} for lazy apply logic ONLY: pin items are considered
+		 * a valid local hit here, since a pin records the instance's globally registered objectId -
+		 * exactly the value {@code ensureObjectId} would return for it. This turns the pin into a
+		 * local cache and saves the global registry round trip for repeated references to already
+		 * stored instances.
+		 * <p>
+		 * Must NEVER be used by explicit stores ({@code internalStore}) or eager applies: for those,
+		 * a local hit means "already handled by this storer" and a pin hit would silently suppress
+		 * the required (re-)serialization (see {@link PinItem} and {@link #lookupOid(Object)}).
+		 */
+		private long lookupOidLazyApplicable(final Object object)
+		{
+			return this.lookupOid(object, true);
+		}
+
+		private long lookupOid(final Object object, final boolean includePins)
+		{
 			synchronized(this.objectRegistryMonitor)
 			{
 				for(Item e = this.hashSlots[identityHashCode(object) & this.hashRange]; e != null; e = e.link)
 				{
-					/*
-					 * Pin items are pure GC-protection entries for skipped referents and must be invisible
-					 * here: a lookup hit means "this storer already handled the instance", which would make
-					 * explicit stores (internalStore) and eager applies silently no-ops for merely
-					 * referenced instances.
-					 */
-					if(e.instance == object && !isPinItem(e))
+					// note: a pin hit may not end the search, a regular item for the instance may still follow.
+					if(e.instance == object && (includePins || !isPinItem(e)))
 					{
 						return e.oid;
 					}
@@ -785,26 +807,12 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			synchronized(this.objectRegistryMonitor)
 			{
 				// any existing local entry (regular, skip or pin) already holds the instance strongly
-				for(Item e = this.hashSlots[identityHashCode(instance) & this.hashRange]; e != null; e = e.link)
+				if(Swizzling.isFoundId(this.lookupOidLazyApplicable(instance)))
 				{
-					if(e.instance == instance)
-					{
-						return;
-					}
+					return;
 				}
 
-				if(++this.itemCount >= this.hashRange)
-				{
-					this.synchRebuildStoreItems();
-				}
-
-				this.hashSlots[identityHashCode(instance) & this.hashRange] =
-					new PinItem(
-						instance,
-						objectId,
-						this.hashSlots[identityHashCode(instance) & this.hashRange]
-					)
-				;
+				this.synchRegisterItem(instance, null, objectId, true);
 			}
 		}
 
@@ -877,18 +885,27 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			final long                                      objectId
 		)
 		{
+			return this.synchRegisterItem(instance, (PersistenceTypeHandler<Binary, Object>)typeHandler, objectId, false);
+		}
+
+		private Item synchRegisterItem(
+			final Object                                 instance   ,
+			final PersistenceTypeHandler<Binary, Object> typeHandler,
+			final long                                   objectId   ,
+			final boolean                                pin
+		)
+		{
 			if(++this.itemCount >= this.hashRange)
 			{
 				this.synchRebuildStoreItems();
 			}
 
-			return this.hashSlots[identityHashCode(instance) & this.hashRange] =
-				new Item(
-					instance,
-					objectId,
-					(PersistenceTypeHandler<Binary, Object>)typeHandler,
-					this.hashSlots[identityHashCode(instance) & this.hashRange]
-				)
+			// slot index may only be computed AFTER the potential rebuild changed the hash range.
+			final int slotIndex = identityHashCode(instance) & this.hashRange;
+
+			return this.hashSlots[slotIndex] = pin
+				? new PinItem(instance, objectId, this.hashSlots[slotIndex])
+				: new Item(instance, objectId, typeHandler, this.hashSlots[slotIndex])
 			;
 		}
 

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
@@ -141,6 +141,7 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		private Item[] hashSlots;
 		private int    hashRange;
 		private long   itemCount;
+		private long   pinCount ; // subset of itemCount: pure retention entries (see PinItem), no store payload.
 		
 		private final BulkList<PersistenceCommitListener>  commitListeners = BulkList.New(0);
 		
@@ -230,7 +231,13 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		{
 			synchronized(this.objectRegistryMonitor)
 			{
-				return this.itemCount;
+				/*
+				 * Pin entries are pure retention entries, not store payload: they must not count into
+				 * the storer's reported size. Otherwise count-based flush controllers (see Batching)
+				 * would flush prematurely for mere references to already stored instances, and a
+				 * pins-only storer would report non-empty and commit an empty chunk.
+				 */
+				return this.itemCount - this.pinCount;
 			}
 		}
 		
@@ -310,6 +317,7 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			synchronized(this.objectRegistryMonitor)
 			{
 				this.itemCount = 0;
+				this.pinCount  = 0;
 				this.hashSlots = new Item[hashLength];
 				this.hashRange = hashLength - 1;
 
@@ -719,12 +727,18 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				{
 					if(e.instance == object)
 					{
-						if(isSkipItem(e))
+						/*
+						 * Pin entries are checked explicitly, NOT via the skip-item criterion they
+						 * happen to satisfy as well (null typeHandler): semantically, a skip is a
+						 * user assertion while a pin is a retention entry - a future change to
+						 * either criterion must not silently expose pins to peer storers here.
+						 */
+						if(isPinItem(e) || isSkipItem(e))
 						{
-							// skip-entry for this storer, so it can offer nothing to the receiver.
+							// local-only entry for this storer, so it can offer nothing to the receiver.
 							break;
 						}
-						
+
 						// found a local entry in the current storer, transfer object<->id association to the receiver.
 						objectIdRequestor.registerGuaranteed(e.oid, object, optionalHandler);
 						return e.oid;
@@ -895,6 +909,11 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			final boolean                                pin
 		)
 		{
+			// pins occupy a hash slot entry (hence itemCount for the rebuild threshold), but are no payload (see size()).
+			if(pin)
+			{
+				++this.pinCount;
+			}
 			if(++this.itemCount >= this.hashRange)
 			{
 				this.synchRebuildStoreItems();
@@ -1092,7 +1111,21 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			// default is eager logic.
 			this.registerGuaranteed(objectId, instance, optionalHandler);
 		}
-		
+
+		@Override
+		public <T> void registerSkippedOptional(
+			final long                              objectId       ,
+			final T                                 instance       ,
+			final PersistenceTypeHandler<Binary, T> optionalHandler
+		)
+		{
+			/*
+			 * No-op: an eager storer processes every encountered instance via registerEagerOptional
+			 * (-> registerGuaranteed), creating a regular item that both retains the instance strongly
+			 * and serializes it. A pin would only duplicate that entry.
+			 */
+		}
+
 	}
 
 	/**
@@ -1519,8 +1552,9 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 	 * Pure pin entry for a skipped referent (see {@code Default#registerSkippedOptional}): holds the
 	 * instance strongly until commit/clear so the storage GC cannot delete the referenced entity while
 	 * the chunk referencing it is not yet committed. Never part of the item chain (not serialized, not
-	 * merged) and invisible to {@code lookupOid}, so explicit stores and eager applies still process
-	 * the instance normally.
+	 * merged), invisible to {@code lookupOid}, so explicit stores and eager applies still process
+	 * the instance normally, and not counted into {@code size()}/{@code isEmpty()} (pins are retention
+	 * entries, not store payload).
 	 */
 	static final class PinItem extends Item
 	{

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectIdRequestor.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectIdRequestor.java
@@ -20,11 +20,12 @@ package org.eclipse.serializer.persistence.types;
  * (e.g. enqueuing the instance for the next storage iteration) onto the id-assignment step without having to
  * inspect the registry afterwards.
  * <p>
- * The three callbacks model the storage strategies the caller may want to express. {@code registerGuaranteed}
+ * The callbacks model the storage strategies the caller may want to express. {@code registerGuaranteed}
  * always fires &mdash; the storer must process the instance unconditionally. {@code registerLazyOptional} and
  * {@code registerEagerOptional} are dispatched only by the lazy and eager storer implementations
  * respectively, so a storer can declare its intent by which method it overrides and use the {@link NoOp}
- * default for the others.
+ * default for the others. {@code registerSkippedOptional} fires when an instance is already globally known
+ * and therefore skipped &mdash; only its object id gets referenced, no serialization happens.
  * <p>
  * For visitors that only need the bare object id (without instance or handler), implement
  * {@link PersistenceObjectIdAcceptor} instead.
@@ -82,6 +83,31 @@ public interface PersistenceObjectIdRequestor<D>
 		T                            instance       ,
 		PersistenceTypeHandler<D, T> optionalHandler
 	);
+
+	/**
+	 * Optional hook fired when the passed instance is already globally known (registered in the object
+	 * registry) and is therefore skipped by lazy storing logic: only its object id gets referenced, the
+	 * instance itself is not serialized. Default is a no-op.
+	 * <p>
+	 * Storers can use this to retain a strong reference to the skipped instance until commit. Without it,
+	 * the application may drop its last strong reference to the instance between store and commit; the
+	 * instance's object registry entry gets reaped and the storage garbage collector can delete the
+	 * referenced entity while the chunk referencing it is not yet committed, so the commit would persist
+	 * a dangling reference (missing entity on later loads).
+	 *
+	 * @param <T>             the instance type.
+	 * @param objectId        the object id the instance is already registered with.
+	 * @param instance        the skipped instance.
+	 * @param optionalHandler the type handler responsible for {@code instance}, or {@code null} if not known.
+	 */
+	public default <T> void registerSkippedOptional(
+		final long                         objectId       ,
+		final T                            instance       ,
+		final PersistenceTypeHandler<D, T> optionalHandler
+	)
+	{
+		// no-op by default
+	}
 
 
 

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectManager.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectManager.java
@@ -315,7 +315,19 @@ extends PersistenceSwizzlingLookup, PersistenceObjectIdHolder, Cloneable<Persist
 					// lazy logic means only apply if not yet globally known (= something new / "store required").
 					objectIdRequestor.registerLazyOptional(objectId, object, optionalHandler);
 				}
-				
+				else
+				{
+					/*
+					 * Already globally known means lazy storing logic skips the instance: only its objectId
+					 * gets referenced in the store, the instance itself is not serialized. The requestor
+					 * (storer) must get the chance to retain the skipped instance, otherwise the application
+					 * can drop its last strong reference between store and commit, the registry's weak entry
+					 * gets reaped and the storage GC deletes the entity while the chunk referencing it is
+					 * not yet committed - the commit would then persist a dangling reference.
+					 */
+					objectIdRequestor.registerSkippedOptional(objectId, object, optionalHandler);
+				}
+
 				// eager logic means ALWAYS apply, even if already globally known (= "store full").
 				objectIdRequestor.registerEagerOptional(objectId, object, optionalHandler);
 


### PR DESCRIPTION
## What this fixes

When storing an object graph, the storer skips objects it believes are already in the storage and only writes their object ids into the data. Between that skip decision (`store()`) and the actual write (`commit()`), nothing holds on to the skipped object. If the application drops its last reference in exactly that window, the JVM garbage-collects the instance, its object-registry entry disappears, and the storage-side garbage collector may legitimately delete the entity from disk - while the in-flight commit still writes a reference to it.

Nothing fails at that moment. The damage only surfaces much later, when a load follows that reference and aborts with `StorageExceptionConsistency: No entity found for objectId N` - typically after a restart, with no hint of when or how the reference went dangling.

The fix is simple in spirit: while a store is in flight, the storer keeps every skipped object strongly referenced until its commit completes, so the object (and through the existing GC safety nets, its on-disk entity) cannot disappear mid-store. The window is realistic with long-lived and batching storers.

## Details

This PR consists of two commits: the fix itself, and a refinement that puts the pins to additional use.

**Commit 1 - the fix (pinning):**

- New default no-op hook `PersistenceObjectIdRequestor.registerSkippedOptional(long objectId, T instance, PersistenceTypeHandler optionalHandler)`, fired from the global-registry-hit branch of `PersistenceObjectManager.Default.ensureObjectId` - i.e. exactly when lazy storing logic skips an already-known instance and only references its object id.
- `BinaryStorer` implements the hook with a new `PinItem extends Item` inserted into the storer-local hash slots: a strong, per-instance deduplicated reference that lives until the storer completes/reinitializes. Pin items are never part of the item chain: they are not serialized and not merged into the global registry.
- Pins are invisible to lookupOid: a lookup hit means "this storer already handled the instance", so explicit stores and eager applies still re-serialize a previously skipped instance instead of short-circuiting on the pin (the recovery path storer.storeAll(parent, child) keeps working). In this commit the pin is purely a retention measure - repeated encounters still resolve via the global registry; commit 2 refines that.

**Commit 2 - the refinement (pin visibility split by lookup semantics):**

- For the **lazy `apply(...)` paths**, a pin is a valid local hit: a pin records exactly the object id the global registry returned when the pin was created, and while the pin holds the instance strongly, its registry entry cannot be reaped nor its id re-mapped - so the cached id cannot go stale. Repeated references to an already-stored instance therefore resolve storer-locally instead of taking the global-registry round trip per reference, which makes reference-dense stores faster than they were before this fix.
- For **explicit stores (`internalStore`) and eager applies**, pins remain deliberately invisible to the lookup: there, a local hit means "this storer already handled the instance", and a pin hit would silently suppress the required (re-)serialization. An explicit recovery store (`storer.storeAll(parent, child)`) still re-serializes the pinned child instead of short-circuiting on the pin. This boundary is documented on both lookup methods; on the store side, the GigaMap suite exercises it heavily (a violation surfaces there as lost segment updates).
- Item registration is unified into a single core (`synchRegisterItem`) that constructs either an `Item` or a `PinItem`, and the pin deduplication reuses the lazy-apply lookup.

**Behavioral notes:**

- Pin items occupy hash-slot entries but are excluded from size()/isEmpty() — they are retention entries, not store payload. A storer holding only pins reports empty and its commit() skips the write entirely.
- A repeated encounter of a pinned instance no longer dispatches through ensureObjectId. This skips a redundant re-dispatch of registerSkippedOptional (the pin it would create already exists — the hook deduplicates anyway) and registerEagerOptional, which is a no-op for lazy storers.

## Scope and pairing

- Serializer-only; no store-side code changes and no API breakage (the hook has a default).
- Regression tests land in the paired store PR (`test/lazy-skip-pinning-73`):
  `StorerCommitWindowDanglingReferenceReproTest` (the commit-window scenario end to end, red against serializer main, green with this branch) and `SkipPinningTest` (the four pin properties: retention during the window, release on commit, per-instance deduplication, and - guarding the commit-2 boundary at unit level - invisibility to explicit stores).
- Additionally verified with this branch installed: the full serializer integration suite (923 tests), the store-side GigaMap module suite (1043 tests, paired with a main-based store build), and the paired store pin tests.
- This PR is the prevention half; the store-time reference-validation feature (detection) stacks on this branch and follows in a separate PR.
