### PR TITLE
Lazy premature link in binary handler lazy dangling oid

### DIFF
--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/org/eclipse/serializer/reference/BinaryHandlerControlledLazy.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/org/eclipse/serializer/reference/BinaryHandlerControlledLazy.java
@@ -95,8 +95,15 @@ public final class BinaryHandlerControlledLazy extends AbstractBinaryHandlerCust
 			referenceOid = handler.apply(referent);
 		}
 
-		// link to object supplier (internal logic can either update, discard or throw exception on mismatch)
-		instance.$link(referenceOid, handler.getObjectRetriever());
+		/*
+		 * Link to object supplier (internal logic can either update, discard or throw exception on
+		 * mismatch) - but DEFERRED to the successful commit, so a failed commit cannot leave a
+		 * stale, never-persisted objectId on the instance (see BinaryHandlerLazyDefault#store).
+		 */
+		final ObjectSwizzling objectRetriever = handler.getObjectRetriever();
+		handler.registerCommitListener(() ->
+			instance.$link(referenceOid, objectRetriever)
+		);
 
 		// lazy reference instance must be stored in any case
 		data.storeEntityHeader(Binary.referenceBinaryLength(1), this.typeId(), objectId);

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/org/eclipse/serializer/reference/BinaryHandlerControlledLazy.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/org/eclipse/serializer/reference/BinaryHandlerControlledLazy.java
@@ -16,12 +16,14 @@ package org.eclipse.serializer.persistence.binary.org.eclipse.serializer.referen
 
 import org.eclipse.serializer.persistence.binary.types.AbstractBinaryHandlerCustom;
 import org.eclipse.serializer.persistence.binary.types.Binary;
+import org.eclipse.serializer.persistence.exceptions.PersistenceException;
 import org.eclipse.serializer.persistence.types.PersistenceLoadHandler;
 import org.eclipse.serializer.persistence.types.PersistenceReferenceLoader;
 import org.eclipse.serializer.persistence.types.PersistenceStoreHandler;
 import org.eclipse.serializer.reference.ControlledLazyReference;
 import org.eclipse.serializer.reference.Lazy;
 import org.eclipse.serializer.reference.ObjectSwizzling;
+import org.eclipse.serializer.reference.Swizzling;
 import org.eclipse.serializer.reflect.XReflect;
 
 import java.lang.reflect.Constructor;
@@ -93,6 +95,16 @@ public final class BinaryHandlerControlledLazy extends AbstractBinaryHandlerCust
 		{
 			// OID validation or updating is done by linking logic
 			referenceOid = handler.apply(referent);
+
+			// fail BEFORE anything is written (see BinaryHandlerLazyDefault#store)
+			if(Swizzling.isFoundId(instance.objectId()) && instance.objectId() != referenceOid)
+			{
+				throw new PersistenceException(
+						"Cannot persist a lazy reference that is already linked to a different objectId. " +
+								"Linked: " + instance.objectId() + ", resolved in this context: " + referenceOid + ". " +
+								"The lazy reference most likely belongs to another storage."
+				);
+			}
 		}
 
 		/*

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/org/eclipse/serializer/reference/BinaryHandlerLazyDefault.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/org/eclipse/serializer/reference/BinaryHandlerLazyDefault.java
@@ -24,6 +24,7 @@ import org.eclipse.serializer.persistence.types.PersistenceReferenceLoader;
 import org.eclipse.serializer.persistence.types.PersistenceStoreHandler;
 import org.eclipse.serializer.reference.Lazy;
 import org.eclipse.serializer.reference.ObjectSwizzling;
+import org.eclipse.serializer.reference.Swizzling;
 import org.eclipse.serializer.reflect.XReflect;
 
 
@@ -111,6 +112,23 @@ public final class BinaryHandlerLazyDefault extends AbstractBinaryHandlerCustom<
 		{
 			// OID validation or updating is done by linking logic
 			referenceOid = handler.apply(referent);
+
+			/*
+			 * Fail BEFORE anything is written: the deferred link below performs the identical
+			 * validation, but it runs only after the commit's write succeeded. A mismatch - the
+			 * lazy reference is already linked to a different objectId, e.g. because it was
+			 * loaded from one storage and is being persisted into another, where the referent
+			 * resolves to a different objectId - must abort the store cleanly instead of
+			 * surfacing only after the data is already durable.
+			 */
+			if(Swizzling.isFoundId(instance.objectId()) && instance.objectId() != referenceOid)
+			{
+				throw new PersistenceException(
+						"Cannot persist a lazy reference that is already linked to a different objectId. " +
+								"Linked: " + instance.objectId() + ", resolved in this context: " + referenceOid + ". " +
+								"The lazy reference most likely belongs to another storage."
+				);
+			}
 		}
 
 		/*

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/org/eclipse/serializer/reference/BinaryHandlerLazyDefault.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/org/eclipse/serializer/reference/BinaryHandlerLazyDefault.java
@@ -113,8 +113,22 @@ public final class BinaryHandlerLazyDefault extends AbstractBinaryHandlerCustom<
 			referenceOid = handler.apply(referent);
 		}
 
-		// link to object supplier (internal logic can either update, discard or throw exception on mismatch)
-		instance.$link(referenceOid, handler.getObjectRetriever());
+		/*
+		 * Link to object supplier (internal logic can either update, discard or throw exception on
+		 * mismatch) - but DEFERRED to the successful commit: linking here would flip isStored() to
+		 * true although nothing has been persisted yet. If the commit write fails, the objectId is
+		 * never merged into the object registry and the referent's data never reaches the storage,
+		 * but the instance would keep reporting a stale, never-persisted objectId. An isStored()-
+		 * gated clear (e.g. by the LazyReferenceManager under memory pressure) would then drop the
+		 * referent, and a later successful store would persist the stale objectId as a dangling
+		 * reference (missing entity on load). Commit listeners run only after the write succeeded
+		 * and the object registry merged, so on a failed commit the instance simply remains in its
+		 * previous state (unstored and thus not clearable, or linked to its prior valid objectId).
+		 */
+		final ObjectSwizzling objectRetriever = handler.getObjectRetriever();
+		handler.registerCommitListener(() ->
+			instance.$link(referenceOid, objectRetriever)
+		);
 
 		// lazy reference instance must be stored in any case
 		data.storeEntityHeader(Binary.referenceBinaryLength(1), this.typeId(), objectId);

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
@@ -618,6 +618,10 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		 * fault must neither prevent the remaining listeners from running (e.g. the deferred Lazy
 		 * linking of the same commit), nor skip the storer cleanup, nor masquerade as a commit
 		 * failure to the caller — the store IS committed at this point.
+		 * <p>
+		 * Isolation covers {@link Exception}s. An {@link Error} signals a fatal JVM condition and
+		 * is intentionally NOT swallowed: it aborts the remaining notifications and propagates,
+		 * but the storer cleanup is still guaranteed by {@link #commit()}'s try/finally.
 		 *
 		 * @return {@code null} if all listeners completed normally, otherwise a
 		 *         {@link PersistenceException} stating that the store was committed successfully,
@@ -635,7 +639,7 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				}
 				catch(final Exception e)
 				{
-					logger.error("Commit listener failed after successful commit", e);
+					logger.error("Commit listener {} failed after successful commit", listener, e);
 					faults.add(e);
 				}
 			});
@@ -692,8 +696,15 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				this.objectManager.mergeEntries(this);
 			}
 			// fault-isolated: the store is durable at this point, cleanup must happen in any case
-			final PersistenceException listenerFault = this.notifyCommitListeners();
-			this.clear();
+			final PersistenceException listenerFault;
+			try
+			{
+				listenerFault = this.notifyCommitListeners();
+			}
+			finally
+			{
+				this.clear();
+			}
 
 			if(listenerFault != null)
 			{

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
@@ -17,6 +17,7 @@ package org.eclipse.serializer.persistence.binary.types;
 import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.hashing.XHashing;
 import org.eclipse.serializer.math.XMath;
+import org.eclipse.serializer.persistence.exceptions.PersistenceException;
 import org.eclipse.serializer.persistence.types.*;
 import org.eclipse.serializer.reference.ObjectSwizzling;
 import org.eclipse.serializer.reference.Swizzling;
@@ -611,9 +612,49 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			this.persistenceObjectRegistrationListener.add(listener);
 		}
 		
-		protected void notifyCommitListeners()
+		/**
+		 * Notifies all registered commit listeners, fault-isolating each one: commit listeners run
+		 * AFTER the point of durability (target write and object registry merge), so a listener
+		 * fault must neither prevent the remaining listeners from running (e.g. the deferred Lazy
+		 * linking of the same commit), nor skip the storer cleanup, nor masquerade as a commit
+		 * failure to the caller — the store IS committed at this point.
+		 *
+		 * @return {@code null} if all listeners completed normally, otherwise a
+		 *         {@link PersistenceException} stating that the store was committed successfully,
+		 *         with the first listener fault as its cause and any further faults suppressed.
+		 *         {@link #commit()} rethrows it AFTER the storer cleanup.
+		 */
+		protected PersistenceException notifyCommitListeners()
 		{
-			this.commitListeners.iterate(PersistenceCommitListener::onAfterCommit);
+			final BulkList<Exception> faults = BulkList.New(0);
+			this.commitListeners.iterate(listener ->
+			{
+				try
+				{
+					listener.onAfterCommit();
+				}
+				catch(final Exception e)
+				{
+					logger.error("Commit listener failed after successful commit", e);
+					faults.add(e);
+				}
+			});
+
+			if(faults.isEmpty())
+			{
+				return null;
+			}
+
+			final PersistenceException fault = new PersistenceException(
+				"The store was committed successfully, but " + faults.size() + " commit listener(s) failed.",
+				faults.first()
+			);
+			for(long i = 1; i < faults.size(); i++)
+			{
+				fault.addSuppressed(faults.at(i));
+			}
+
+			return fault;
 		}
 
 		@Override
@@ -650,8 +691,15 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				this.typeManager.clearStorePendingRoots();
 				this.objectManager.mergeEntries(this);
 			}
-			this.notifyCommitListeners();
+			// fault-isolated: the store is durable at this point, cleanup must happen in any case
+			final PersistenceException listenerFault = this.notifyCommitListeners();
 			this.clear();
+
+			if(listenerFault != null)
+			{
+				// distinct from a commit (write/durability) failure - see #notifyCommitListeners
+				throw listenerFault;
+			}
 
 			logger.debug("Commit finished successfully");
 


### PR DESCRIPTION
# Defer Lazy `$link` to the successful commit to prevent dangling objectIds after a failed commit

## Problem

`BinaryHandlerLazyDefault.store` (and its twin `BinaryHandlerControlledLazy.store`) links the `Lazy` instance to its referent's objectId **during serialization**:

```java
instance.$link(referenceOid, handler.getObjectRetriever());
```

This flips `Lazy.isStored()` to `true` before anything has been persisted. If the commit subsequently **fails** (the write throws before the object registry merge), the objectId is never merged into the object registry and the referent's data never reaches the storage — yet the `Lazy` instance keeps reporting a stale, never-persisted objectId.

From there, a perfectly framework-legal sequence turns this into silent data loss:

1. `store()` on an explicit lazy storer serializes the graph; the handler links the `Lazy` to the freshly assigned objectId X.
2. `commit()` fails (I/O error, write controller, full disk, …). Nothing was persisted; X is unknown to the registry and to the storage.
3. The `LazyReferenceManager` (or any `isStored()`-gated logic) clears the `Lazy` under memory pressure — legal, because `isStored()` claims the referent is safely on disk. The referent is now **gone from memory**.
4. A later store succeeds. The handler takes the `referent == null` branch and persists `instance.objectId()` — the stale X — as the reference value.
5. On the next load: `StorageExceptionConsistency: No entity found for objectId X`. The referent's data is unrecoverable.

This is the same failure symptom as #289 but a different root cause: #289 covered lazily-**skipped** instances losing their pin during the commit window; this covers the `Lazy` instance itself being linked **too early**.

## Fix

### 1. Defer the link to the successful commit (both lazy handlers)

`store()` no longer calls `$link` directly. Instead it registers the link as a commit listener:

```java
final ObjectSwizzling objectRetriever = handler.getObjectRetriever();
handler.registerCommitListener(() ->
    instance.$link(referenceOid, objectRetriever)
);
```

Commit listeners run in `BinaryStorer.commit` only **after** the target write succeeded and the object registry merged. On a failed commit the `Lazy` instance simply remains in its previous state: unstored (and thus not clearable), or linked to its prior, valid objectId. The dangling-reference sequence above becomes impossible.

### 2. Keep store-time validation store-time (both lazy handlers)

`$link` also validates that an already-linked instance is not being re-linked to a *different* objectId (the typical trigger: a `Lazy` loaded from storage A being persisted into storage B, where the referent resolves to a different id). Deferring the link would have moved that error **behind** the write — the store would succeed on disk and the error would surface afterwards. The exact same validation is therefore now performed inline in `store()`, before anything is written:

```java
if(Swizzling.isFoundId(instance.objectId()) && instance.objectId() != referenceOid)
{
    throw new PersistenceException(
        "Cannot persist a lazy reference that is already linked to a different objectId. ..."
    );
}
```

The mismatch aborts the store cleanly pre-write — the same protection the unloaded-referent branch already has. The deferred link's own validation remains as a backstop.

### 3. Fault-isolate commit listener notification (`BinaryStorer`)

Commit listeners now run after the point of durability, so a listener fault must not be allowed to:

- **skip the remaining listeners** — the other `Lazy` instances of the same commit would stay unlinked although their data is durable;
- **skip the storer cleanup** — a reused batching storer would retain the listener and re-fire it on every subsequent flush;
- **masquerade as a commit failure** — callers would assume nothing was persisted when in fact everything was.

`notifyCommitListeners` now catches and logs each listener fault, always runs all listeners, and `commit()` performs the storer cleanup (`clear()`) before rethrowing a single, deliberately distinct exception:

> `The store was committed successfully, but N commit listener(s) failed.`

with the first fault as cause and any further faults suppressed.

## Behavioral changes

- **Explicit storer, `clear()` between `store()` and `commit()`:** a `Lazy` stored but not yet committed is now still unstored, so `Lazy#clear` throws `Cannot clear an unstored lazy reference` in that window (previously it silently dropped the referent — which is exactly the data-loss hole this PR closes). `forceClear()` remains available where the caller knows what they are doing. Implicit `storage.store(...)` is unaffected — store and commit are synchronous there.
- **Cross-storage store of a loaded `Lazy`:** still fails, but now with the explicit pre-write message above instead of the generic `$link` mismatch error, and guaranteed before anything is written.
- **Memory-reclaim timing:** a just-stored `Lazy` becomes clearable at commit time instead of serialization time — a delay of the storer's store→commit window, negligible in practice.







