### PR TITLE
Add a registration version to the object registry for the storage GC's mid-cycle re-seed

### DIFF
--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/DefaultObjectRegistry.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/DefaultObjectRegistry.java
@@ -259,6 +259,15 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 	private long    capacity    ; // upper rebuild threshold.
 	private long    minCapacity ; // minimum capacity
 	private long    size        ;
+
+	/*
+	 * Monotonically increasing counter of new objectId<->instance association insertions
+	 * (see PersistenceObjectRegistry#registrationVersion). Written only inside synchronized(mutex)
+	 * sections (single writer at a time), read lock-free (volatile) by the storage garbage
+	 * collector to detect registrations that happened after its live-OID mark seed ran.
+	 * Lookups, updates of existing entries and removals do not change it.
+	 */
+	private volatile long registrationVersion;
 	
 	// integrated special constants registry
 	private EqHashTable<Long, Object> constantsHotRegistry = EqHashTable.New();
@@ -419,6 +428,13 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 		{
 			return this.size == 0;
 		}
+	}
+
+	@Override
+	public final long registrationVersion()
+	{
+		// deliberately unsynchronized: volatile read, snapshot comparison semantics (see interface javadoc).
+		return this.registrationVersion;
 	}
 
 	@Override
@@ -751,6 +767,9 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 		{
 			this.synchIncreaseStorage();
 		}
+
+		// single choke point for ALL new association insertions; see field comment.
+		this.registrationVersion++;
 	}
 	
 	private boolean synchAddCheck(final long objectId, final Object object)

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectRegistry.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectRegistry.java
@@ -325,7 +325,30 @@ public interface PersistenceObjectRegistry extends PersistenceSwizzlingLookup, C
 		//by default do nothing
 		return;
 	}
-	
+
+	/**
+	 * A monotonically increasing counter of new {@code (objectId, instance)} association insertions.
+	 * The value changes ONLY when a new association is inserted (registering an object or constant
+	 * that creates a new entry, including re-binding an objectId whose previous weak entry was
+	 * cleared). Lookups, updates of existing entries and entry removals do NOT change it. Readers
+	 * compare snapshots for equality; the absolute value carries no meaning.
+	 * <p>
+	 * The storage garbage collector uses this to detect registrations that happened after its
+	 * live-OID mark seed ran but before the sweep &mdash; such registrations must re-arm the seed, or
+	 * entities referenced only from a freshly registered instance's persisted binary (e.g. an
+	 * unloaded lazy reference's target) would be swept while the registered instance survives.
+	 * <p>
+	 * The default implementation returns a constant {@code 0}, meaning "registrations are never
+	 * observable". Implementations that can gain entries at runtime MUST override this, otherwise
+	 * the storage GC's mid-cycle registration re-seed is disabled for them.
+	 *
+	 * @return the current registration version.
+	 */
+	public default long registrationVersion()
+	{
+		return 0L;
+	}
+
 	/**
 	 * Creates a new empty {@link DefaultObjectRegistry} with default hash density and capacity.
 	 *


### PR DESCRIPTION
## What this enables

The storage garbage collector must never delete data the application still holds in memory. To guarantee that, it seeds the "alive" object ids from the application's object registry at the start of each collection cycle. That seed used to run exactly once per cycle - anything the application loaded or registered AFTER the seed but BEFORE the cycle's sweep was invisible to the collector. In one concrete scenario, loading an entity in exactly that window rescued the entity itself but not the target of its not-yet-loaded lazy reference: the target was swept, and the next attempt to resolve the lazy reference failed with  `StorageExceptionConsistency: No entity found for objectId N`.

To close that window, the storage side needs one thing from the registry: a cheap way to detect "has anything new been registered since I last looked?". This PR adds exactly that - a monotonically increasing registration version. The paired store PR re-checks the version at the sweep gate and re-runs the seed if it moved, so mid-cycle registrations get their references walked before anything is deleted.

## Technical details

- `DefaultObjectRegistry` gains a `private volatile long registrationVersion`, incremented at the single choke point through which every new object-id association passes (`synchPutNewEntry` - covering `registerObject`, `optionalRegisterObject`, `registerConstant`, and re-binding after a cleared weak entry). Written only under the registry's mutex, read lock-free via the new `registrationVersion()` accessor. Lookups, updates, removals, and internal housekeeping (`cleanUp`, `consolidate`, rebuilds) do NOT bump the version - only   observable NEW associations do, so the GC is never starved by mere reads.
- `PersistenceObjectRegistry` gets `default long registrationVersion() { return 0L; }`: a constant version means "registrations never observable", which preserves exact pre-PR behavior for custom registry implementations (they can override to opt in). Deliberately NOT an always-changing default - that would make the storage GC re-seed on every check and starve the sweep.

## Scope and pairing

- Serializer-only, additive, no behavioral change by itself - the version is written but not yet consumed.
- The paired store PR (`fix/gc-mid-cycle-registration-race`) consumes it: version snapshot at every live-object-id seed, seed/verify loop at the sweep gate, plus the complementary load-side pending-load gate, and a deterministic regression test (`MidCycleRegistrationRaceTest`) that reproduces the race and verifies both the fix and the unchanged whole-graph collection in the control case.
- This PR must merge before (or together with) the store PR - the store side calls `registrationVersion()`.