### PR TITLE
Exempt used-marked Lazy references from evaluator-driven clearing

### DIFF
--- a/base/src/main/java/org/eclipse/serializer/reference/Lazy.java
+++ b/base/src/main/java/org/eclipse/serializer/reference/Lazy.java
@@ -91,9 +91,15 @@ public interface Lazy<T> extends UsageMarkable, Referencing<T>
 	
 	/**
 	 * Clears the reference if the {@link ClearingEvaluator} decides so.
-	 * 
+	 * <p>
+	 * A reference that is currently marked as used (see {@link UsageMarkable#markUsedFor(Object)} and
+	 * {@link UsageMarkable#isUsed()}) is never cleared by this method, without consulting the evaluator:
+	 * a usage mark signals that the referent carries state that must not be dropped (e.g. not yet
+	 * persisted changes), so evaluator-driven eviction must leave it untouched. The explicit
+	 * {@link #clear()} and {@link #forceClear()} calls are not affected by usage marks.
+	 *
 	 * @param clearingEvaluator evaluator to decide if the clearing should take place
-	 * 
+	 *
 	 * @return <code>true</code> if this lazy reference was cleared, <code>false</code> otherwise
 	 */
 	public boolean clear(Lazy.ClearingEvaluator clearingEvaluator);
@@ -407,8 +413,8 @@ public interface Lazy<T> extends UsageMarkable, Referencing<T>
 		@Override
 		public synchronized boolean clear(final ClearingEvaluator clearingEvaluator)
 		{
-			// must be stored and not already cleared to even consider asking the evaluator
-			if(this.isStored() && this.subject != null && clearingEvaluator.needsClearing(this))
+			// must be stored, not already cleared and not marked as used to even consider asking the evaluator
+			if(this.isStored() && this.subject != null && !this.isUsed() && clearingEvaluator.needsClearing(this))
 			{
 				this.internalClear();
 				return true;

--- a/base/src/main/java/org/eclipse/serializer/reference/UsageMarkable.java
+++ b/base/src/main/java/org/eclipse/serializer/reference/UsageMarkable.java
@@ -170,9 +170,21 @@ public interface UsageMarkable
         @Override
         public boolean isUsed()
         {
+            /*
+             * Deliberately NOT via usageMarks(): that would ALLOCATE the marks collection for
+             * every instance this is called on. isUsed() is queried by evaluator-driven lazy
+             * clearing for every stored+loaded reference in every check cycle - never-marked
+             * instances (the vast majority) must answer false without any allocation.
+             * The field is volatile: a null read means no mark was ever registered.
+             */
+            final HashEnum<Object> usageMarks = this.usageMarks;
+            if(usageMarks == null)
+            {
+                return false;
+            }
+
             // lock internal instance to avoid side effect deadlocks
-            final HashEnum<Object> usageMarks;
-            synchronized((usageMarks = this.usageMarks()))
+            synchronized(usageMarks)
             {
                 return !usageMarks.isEmpty();
             }

--- a/base/src/main/java/org/eclipse/serializer/reference/UsageMarkable.java
+++ b/base/src/main/java/org/eclipse/serializer/reference/UsageMarkable.java
@@ -19,6 +19,7 @@ import java.util.function.Consumer;
 import org.eclipse.serializer.collections.HashEnum;
 import org.eclipse.serializer.collections.types.XGettingCollection;
 import org.eclipse.serializer.collections.types.XGettingEnum;
+import org.eclipse.serializer.util.X;
 
 public interface UsageMarkable
 {
@@ -66,6 +67,17 @@ public interface UsageMarkable
 	 */
 	public int markUnused();
 
+	/**
+	 * Executes the passed logic with the internal usage marks collection.
+	 * <p>
+	 * <b>Lock-order constraint:</b> the logic runs while holding the internal marks monitor.
+	 * It must not call back into synchronized methods of the marked instance (for a {@link Lazy},
+	 * e.g. {@code peek()}, {@code get()}, {@code clear(...)}): evaluator-driven lazy clearing
+	 * acquires the instance monitor first and queries {@link #isUsed()} (the marks monitor)
+	 * second — a callback from here into the instance inverts that order and can deadlock.
+	 *
+	 * @param logic the logic to execute with the usage marks collection.
+	 */
 	public void accessUsageMarks(Consumer<? super XGettingEnum<Object>> logic);
 
 	
@@ -157,9 +169,15 @@ public interface UsageMarkable
         @Override
         public int unmarkUsedFor(final Object instance)
         {
+            // never marked: nothing to remove, nothing to allocate (see isUsed()).
+            final HashEnum<Object> usageMarks = this.usageMarks;
+            if(usageMarks == null)
+            {
+                return 0;
+            }
+
             // lock internal instance to avoid side effect deadlocks
-            final HashEnum<Object> usageMarks;
-            synchronized((usageMarks = this.usageMarks()))
+            synchronized(usageMarks)
             {
                 final boolean removed = usageMarks.removeOne(instance);
 
@@ -193,9 +211,15 @@ public interface UsageMarkable
         @Override
         public int markUnused()
         {
+            // never marked: nothing to clear, nothing to allocate (see isUsed()).
+            final HashEnum<Object> usageMarks = this.usageMarks;
+            if(usageMarks == null)
+            {
+                return 0;
+            }
+
             // lock internal instance to avoid side effect deadlocks
-            final HashEnum<Object> usageMarks;
-            synchronized((usageMarks = this.usageMarks()))
+            synchronized(usageMarks)
             {
                 final int currentSize = usageMarks.intSize();
                 usageMarks.clear();
@@ -207,11 +231,20 @@ public interface UsageMarkable
         @Override
         public void accessUsageMarks(final Consumer<? super XGettingEnum<Object>> logic)
         {
-            // lock internal instance to avoid side effect deadlocks
-            final HashEnum<Object> usageMarks;
-            synchronized((usageMarks = this.usageMarks()))
+            /*
+             * Never marked: the logic still gets a (shared immutable empty) collection so it can
+             * notice the no-marks case, but the instance's own marks storage is not allocated.
+             */
+            final HashEnum<Object> usageMarks = this.usageMarks;
+            if(usageMarks == null)
             {
-                // no null check to give logic a chance to notice no-marks case.
+                logic.accept(X.empty());
+                return;
+            }
+
+            // lock internal instance to avoid side effect deadlocks
+            synchronized(usageMarks)
+            {
                 logic.accept(usageMarks);
             }
         }

--- a/base/src/main/java/org/eclipse/serializer/reference/UsageMarkable.java
+++ b/base/src/main/java/org/eclipse/serializer/reference/UsageMarkable.java
@@ -48,8 +48,17 @@ public interface UsageMarkable
 	 */
 	public int unmarkUsedFor(Object instance);
 	
+	/**
+	 * Returns whether at least one usage mark is currently registered.
+	 * <p>
+	 * A used-marked {@link Lazy} reference is exempt from evaluator-driven clearing
+	 * (see {@link Lazy#clear(Lazy.ClearingEvaluator)}): the marks signal that the referent
+	 * carries state that must not be dropped, e.g. changes that have not been persisted yet.
+	 *
+	 * @return <code>true</code> if any usage mark is registered, <code>false</code> otherwise.
+	 */
 	public boolean isUsed();
-	
+
 	/**
 	 * Clears ALL usage marks.
 	 * 

--- a/integration-tests/src/test/java/test/eclipse/serializer/reference/LazyUsedEvictionGuardTest.java
+++ b/integration-tests/src/test/java/test/eclipse/serializer/reference/LazyUsedEvictionGuardTest.java
@@ -1,0 +1,97 @@
+package test.eclipse.serializer.reference;
+
+/*-
+ * #%L
+ * Eclipse Serializer Integration Tests
+ * %%
+ * Copyright (C) 2023 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.serializer.reference.Lazy;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for the usage-mark eviction guard in {@link Lazy.Default#clear(Lazy.ClearingEvaluator)}:
+ * a {@link org.eclipse.serializer.reference.UsageMarkable used-marked} lazy reference must never be cleared
+ * by evaluator-driven eviction (the {@code LazyReferenceManager} path), because the usage mark signals that
+ * the referent carries state that must not be dropped, e.g. changes that have not been persisted yet.
+ * <p>
+ * Without the guard, a mutated-but-not-yet-stored referent pinned via
+ * {@link org.eclipse.serializer.reference.UsageMarkable#markUsedFor(Object)} could be evicted by the
+ * periodic lazy clearing, silently losing the unpersisted state (see the GigaMap dirty-segment
+ * lost-update scenario, where exactly this caused persisted index/segment divergence).
+ */
+public class LazyUsedEvictionGuardTest
+{
+	private static final long FAKE_OBJECT_ID = 1_000_000_000_000_000_001L;
+
+	private static Lazy<String> createStoredLoadedLazy(final String payload)
+	{
+		// unregistered to keep the global LazyReferenceManager out of the test
+		final Lazy<String> lazy = Lazy.UnregisteredReference(payload);
+
+		// same linking the framework's type handler performs when the reference gets persisted
+		((Lazy.Default<String>)lazy).$link(FAKE_OBJECT_ID, objectId -> payload);
+
+		return lazy;
+	}
+
+	@Test
+	void evaluatorDrivenClearingSkipsUsedMarkedReference()
+	{
+		final Lazy<String> lazy = createStoredLoadedLazy("payload");
+		assertTrue(lazy.isStored());
+
+		final Lazy.ClearingEvaluator alwaysClear = ref -> true;
+
+		lazy.markUsed();
+		assertFalse(lazy.clear(alwaysClear), "used-marked reference must not be cleared by an evaluator");
+		assertEquals("payload", lazy.peek(), "referent must survive evaluator-driven clearing while used-marked");
+
+		lazy.markUnused();
+		assertTrue(lazy.clear(alwaysClear), "unmarked reference must be clearable by an evaluator again");
+		assertNull(lazy.peek());
+	}
+
+	@Test
+	void guardTracksMarkUnmarkPerInstance()
+	{
+		final Lazy<String> lazy = createStoredLoadedLazy("payload");
+
+		final Object markerA = new Object();
+		final Object markerB = new Object();
+		final Lazy.ClearingEvaluator alwaysClear = ref -> true;
+
+		lazy.markUsedFor(markerA);
+		lazy.markUsedFor(markerB);
+
+		lazy.unmarkUsedFor(markerA);
+		assertFalse(lazy.clear(alwaysClear), "reference must stay pinned while any usage mark remains");
+
+		lazy.unmarkUsedFor(markerB);
+		assertTrue(lazy.clear(alwaysClear), "reference must be clearable once the last usage mark is removed");
+		assertNull(lazy.peek());
+	}
+
+	@Test
+	void explicitClearIgnoresUsageMarks()
+	{
+		final Lazy<String> lazy = createStoredLoadedLazy("payload");
+
+		lazy.markUsed();
+		assertEquals("payload", lazy.clear(), "explicit clear() must stay unconditional");
+		assertNull(lazy.peek());
+	}
+}


### PR DESCRIPTION
## What this fixes

`Lazy` references can be marked as "in use" via the `UsageMarkable` API — the mark's meaning is "the referent carries state that must not be dropped", e.g. modifications that have not been persisted yet. GigaMap uses exactly this: whenever a segment behind a `Lazy` reference is mutated, the segment is pinned via `markUsedFor`, and the pin is released after the changes are committed.

The problem: the mark was write-only. `isUsed()` had no callers anywhere — no clearing path ever consulted it. The `LazyReferenceManager`'s periodic clearing decides purely on `isStored()` plus timeout/memory pressure, so it could evict a loaded-then-mutated-but-not-yet-stored referent. The change flags die with the evicted instance, the next store silently skips the segment, and the mutation is lost — while related non-lazy updates (index entries, size counters) DO get persisted, leaving permanently inconsistent data on disk with no exception anywhere.

The fix wires the read side in: a used-marked `Lazy` reference is never cleared by evaluator-driven eviction.

## Technical details

- `Lazy.Default.clear(ClearingEvaluator)` — the single choke point of the `LazyReferenceManager`'s periodic clearing — now skips used-marked references before even consulting the evaluator: `isStored() && subject != null && !isUsed() && needsClearing(...)`.
 - This covers ALL evaluators (the default `Checker`, custom checks) uniformly. Anyone not calling `markUsedFor` sees zero behavior change.
- The explicit `clear()` / `forceClear()` calls remain unconditional — they are imperative API; callers that combine explicit clearing with usage marks check `isUsed()` themselves (see the paired store PR for GigaMap's `release()`).
 - Lock safety: `clear(...)` holds the `Lazy.Default` instance monitor; `isUsed()` nests the distinct `usageMarks` monitor inside it. That ordering is consistent repo-wide (no reverse nesting exists), so no new deadlock surface.
 - Javadoc on `Lazy.clear(ClearingEvaluator)` and `UsageMarkable.isUsed()` documents the now-enforced contract.

## Test

`LazyUsedEvictionGuardTest` (public API only): an always-clear evaluator cannot clear a used-marked reference and can again once unmarked; marks are tracked per marker instance (the reference stays pinned while any mark remains); explicit `clear()` stays unconditional. Fails 2/3 without the guard.

## Pairing

The store-side counterpart (GigaMap: retain dirty segments in `release()`, plus the end-to-end reproducer showing the silent lost update) is a separate PR — no compile or ordering dependency between the two; each closes one of the two eviction paths.