### PR TITLE
Capture trusted reference object ids in BinaryStorer for target-side validation

### DIFF
--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/org/eclipse/serializer/reference/BinaryHandlerLazyDefault.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/org/eclipse/serializer/reference/BinaryHandlerLazyDefault.java
@@ -107,6 +107,12 @@ public final class BinaryHandlerLazyDefault extends AbstractBinaryHandlerCustom<
 								"Persisting it would result in data loss."
 				);
 			}
+
+			if(referenceOid != 0)
+			{
+				// cached id of an unloaded referent: referenced but not stored in this commit.
+				handler.noteTrustedReference(referenceOid);
+			}
 		}
 		else
 		{

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/Binary.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/Binary.java
@@ -469,6 +469,14 @@ public abstract class Binary implements Chunk
 	long address;
 
 	private HelperEntry helperEntry;
+
+	/**
+	 * Transient store-transport metadata, never part of the persisted data itself: the object ids this
+	 * data references without containing the corresponding entities, trusting that they already exist
+	 * in the persistence target. Set by the storer on commit; the target may validate their existence
+	 * before committing the data.
+	 */
+	private long[] trustedObjectIds;
 	
 	
 	
@@ -2791,10 +2799,35 @@ public abstract class Binary implements Chunk
 	}
 	
 
+	/**
+	 * Sets the transient store-transport metadata of object ids referenced but not contained by this data.
+	 *
+	 * @param trustedObjectIds the referenced object ids whose entities are trusted to already exist in the target.
+	 *
+	 * @see #trustedObjectIds()
+	 */
+	public final void setTrustedObjectIds(final long[] trustedObjectIds)
+	{
+		this.trustedObjectIds = trustedObjectIds;
+	}
+
+	/**
+	 * The object ids this data references without containing the corresponding entities, i.e. ids whose
+	 * entities the storer trusted to already exist in the persistence target. {@code null} if no such ids
+	 * were collected (capturing disabled or nothing to report).
+	 *
+	 * @return the trusted object ids, or {@code null}.
+	 */
+	public final long[] trustedObjectIds()
+	{
+		return this.trustedObjectIds;
+	}
+
+
 	///////////////////////////////////////////////////////////////////////////
 	// Helper //
 	///////////
-	
+
 	/**
 	 * Helper instances can be used as temporary additional state for the duration of the building process.
 	 * E.g.: JDK hash collections cannot properly collect elements during the building process as the element instances

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/Binary.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/Binary.java
@@ -2801,6 +2801,11 @@ public abstract class Binary implements Chunk
 
 	/**
 	 * Sets the transient store-transport metadata of object ids referenced but not contained by this data.
+	 * <p>
+	 * COMMIT-scope metadata, not per-chunk state: it is set exactly once, on the representative
+	 * {@code Binary} instance the storer passes to {@code PersistenceTarget#write}, and covers the
+	 * ENTIRE commit across all channels. Consumers read it from that instance and partition per
+	 * channel themselves; per-channel chunk views deliberately do not carry it.
 	 *
 	 * @param trustedObjectIds the referenced object ids whose entities are trusted to already exist in the target.
 	 *
@@ -2815,6 +2820,10 @@ public abstract class Binary implements Chunk
 	 * The object ids this data references without containing the corresponding entities, i.e. ids whose
 	 * entities the storer trusted to already exist in the persistence target. {@code null} if no such ids
 	 * were collected (capturing disabled or nothing to report).
+	 * <p>
+	 * Commit-scope metadata: only present on the representative instance passed to
+	 * {@code PersistenceTarget#write}, covering the entire commit across all channels
+	 * (see {@link #setTrustedObjectIds(long[])}).
 	 *
 	 * @return the trusted object ids, or {@code null}.
 	 */

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
@@ -15,6 +15,7 @@ package org.eclipse.serializer.persistence.binary.types;
  */
 
 import org.eclipse.serializer.collections.BulkList;
+import org.eclipse.serializer.collections.Set_long;
 import org.eclipse.serializer.hashing.XHashing;
 import org.eclipse.serializer.math.XMath;
 import org.eclipse.serializer.persistence.exceptions.PersistenceException;
@@ -26,6 +27,7 @@ import org.eclipse.serializer.util.logging.Logging;
 import org.slf4j.Logger;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -143,6 +145,15 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		private int    hashRange;
 		private long   itemCount;
 		private long   pinCount ; // subset of itemCount: pure retention entries (see PinItem), no store payload.
+
+		/*
+		 * Object ids this storer writes into the data as references while trusting that the referenced
+		 * entity already exists in the target (global registry hits and unloaded Lazy references' cached
+		 * ids). Null when capturing is disabled, so the feature has zero overhead in that case.
+		 * At commit, ids that are also stored by the commit itself are pruned; the remainder is attached
+		 * to the written Binary for the target to validate. Guarded by objectRegistryMonitor.
+		 */
+		private final Set_long trustedObjectIds;
 		
 		private final BulkList<PersistenceCommitListener>  commitListeners = BulkList.New(0);
 		
@@ -180,6 +191,31 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			final Persister                             persister
 		)
 		{
+			this(
+				objectManager     ,
+				objectRetriever   ,
+				typeManager       ,
+				target            ,
+				bufferSizeProvider,
+				channelCount      ,
+				switchByteOrder   ,
+				persister         ,
+				false
+			);
+		}
+
+		protected Default(
+			final PersistenceObjectManager<Binary>      objectManager          ,
+			final ObjectSwizzling                       objectRetriever        ,
+			final PersistenceTypeHandlerManager<Binary> typeManager            ,
+			final PersistenceTarget<Binary>             target                 ,
+			final BufferSizeProviderIncremental         bufferSizeProvider     ,
+			final int                                   channelCount           ,
+			final boolean                               switchByteOrder        ,
+			final Persister                             persister              ,
+			final boolean                               captureTrustedObjectIds
+		)
+		{
 			super();
 			this.objectManager         = notNull(objectManager)               ;
 			this.objectRegistryMonitor = objectManager.objectRegistryMonitor();
@@ -190,6 +226,7 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			this.chunksHashRange       =         channelCount - 1             ;
 			this.switchByteOrder       =         switchByteOrder              ;
 			this.persister             = mayNull(persister)                   ;
+			this.trustedObjectIds      = captureTrustedObjectIds ? Set_long.New() : null;
 
 			this.defaultInitialize();
 		}
@@ -330,6 +367,11 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				// must be clear instead of just reset to avoid memory leaks
 				this.commitListeners.clear();
 				this.persistenceObjectRegistrationListener.clear();
+
+				if(this.trustedObjectIds != null)
+				{
+					this.trustedObjectIds.clear();
+				}
 			}
 		}
 		
@@ -681,6 +723,12 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 					this.typeManager.checkForPendingRootInstances();
 					this.typeManager.checkForPendingRootsStoring(this);
 					writeData = this.synchComplete();
+
+					final long[] trustedObjectIds = this.synchYieldTrustedObjectIds();
+					if(trustedObjectIds != null)
+					{
+						writeData.setTrustedObjectIds(trustedObjectIds);
+					}
 				}
 
 				// very costly IO-operation does not need to occupy the lock
@@ -718,6 +766,48 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			return null;
 		}
 		
+		/**
+		 * Yields the trusted object ids of the current commit as an array, pruned by the ids the commit
+		 * stores itself: an id that is both referenced and stored in the same commit is guaranteed, not
+		 * trusted (e.g. {@code storeAll(parent, child)} re-storing a registry-known child, or an eager
+		 * storer's items). Returns {@code null} if capturing is disabled or nothing remains after pruning.
+		 * <p>
+		 * Must be called under {@code objectRegistryMonitor}.
+		 */
+		private long[] synchYieldTrustedObjectIds()
+		{
+			if(this.trustedObjectIds == null || this.trustedObjectIds.isEmpty())
+			{
+				return null;
+			}
+
+			final Set_long storedObjectIds = Set_long.New();
+			for(Item e = this.head; (e = e.next) != null;)
+			{
+				if(!isSkipItem(e))
+				{
+					storedObjectIds.add(e.oid);
+				}
+			}
+
+			final long[] buffer = new long[(int)this.trustedObjectIds.size()];
+			final int[]  count  = {0};
+			this.trustedObjectIds.iterate(objectId ->
+			{
+				if(!storedObjectIds.contains(objectId))
+				{
+					buffer[count[0]++] = objectId;
+				}
+			});
+
+			return count[0] == 0
+				? null
+				: count[0] == buffer.length
+					? buffer
+					: Arrays.copyOf(buffer, count[0])
+			;
+		}
+
 		public final long lookupOid(final Object object)
 		{
 			/*
@@ -887,6 +977,10 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			 */
 			synchronized(this.objectRegistryMonitor)
 			{
+				// the skipped id is also a "trusted reference": referenced but not stored in this
+				// commit - record it so the persistence target can validate its existence.
+				this.noteTrustedReference(objectId);
+
 				// any existing local entry (regular, skip or pin) already holds the instance strongly
 				if(Swizzling.isFoundId(this.lookupOidLazyApplicable(instance)))
 				{
@@ -894,6 +988,22 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				}
 
 				this.synchRegisterItem(instance, null, objectId, true);
+			}
+		}
+
+		@Override
+		public final void noteTrustedReference(final long objectId)
+		{
+			// only data object ids can dangle; TIDs/CIDs/null are resolved at runtime, not via entities.
+			if(this.trustedObjectIds == null || !Persistence.IdType.OID.isInRange(objectId))
+			{
+				return;
+			}
+
+			// reentrant from the registerSkippedOptional path; the Lazy handler path acquires it fresh.
+			synchronized(this.objectRegistryMonitor)
+			{
+				this.trustedObjectIds.add(objectId);
 			}
 		}
 
@@ -1133,7 +1243,7 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			final Persister                             persister
 		)
 		{
-			super(
+			this(
 				objectManager     ,
 				objectRetriever   ,
 				typeManager       ,
@@ -1141,7 +1251,33 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				bufferSizeProvider,
 				channelCount      ,
 				switchByteOrder   ,
-				persister
+				persister         ,
+				false
+			);
+		}
+
+		Eager(
+			final PersistenceObjectManager<Binary>      objectManager          ,
+			final ObjectSwizzling                       objectRetriever        ,
+			final PersistenceTypeHandlerManager<Binary> typeManager            ,
+			final PersistenceTarget<Binary>             target                 ,
+			final BufferSizeProviderIncremental         bufferSizeProvider     ,
+			final int                                   channelCount           ,
+			final boolean                               switchByteOrder        ,
+			final Persister                             persister              ,
+			final boolean                               captureTrustedObjectIds
+		)
+		{
+			super(
+				objectManager          ,
+				objectRetriever        ,
+				typeManager            ,
+				target                 ,
+				bufferSizeProvider     ,
+				channelCount           ,
+				switchByteOrder        ,
+				persister              ,
+				captureTrustedObjectIds
 			);
 		}
 		
@@ -1233,27 +1369,29 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		private final Object commitLock = new Object();
 
 		Batching(
-			final PersistenceObjectManager<Binary>      objectManager     ,
-			final ObjectSwizzling                       objectRetriever   ,
-			final PersistenceTypeHandlerManager<Binary> typeManager       ,
-			final PersistenceTarget<Binary>             target            ,
-			final BufferSizeProviderIncremental         bufferSizeProvider,
-			final int                                   channelCount      ,
-			final boolean                               switchByteOrder   ,
-			final Persister                             persister         ,
-			final BatchStorer.Controller                controller        ,
-			final Duration                              checkInterval
+			final PersistenceObjectManager<Binary>      objectManager          ,
+			final ObjectSwizzling                       objectRetriever        ,
+			final PersistenceTypeHandlerManager<Binary> typeManager            ,
+			final PersistenceTarget<Binary>             target                 ,
+			final BufferSizeProviderIncremental         bufferSizeProvider     ,
+			final int                                   channelCount           ,
+			final boolean                               switchByteOrder        ,
+			final Persister                             persister              ,
+			final BatchStorer.Controller                controller             ,
+			final Duration                              checkInterval          ,
+			final boolean                               captureTrustedObjectIds
 		)
 		{
 			super(
-				objectManager     ,
-				objectRetriever   ,
-				typeManager       ,
-				target            ,
-				bufferSizeProvider,
-				channelCount      ,
-				switchByteOrder   ,
-				persister
+				objectManager          ,
+				objectRetriever        ,
+				typeManager            ,
+				target                 ,
+				bufferSizeProvider     ,
+				channelCount           ,
+				switchByteOrder        ,
+				persister              ,
+				captureTrustedObjectIds
 			);
 			this.controller = notNull(controller);
 
@@ -1646,9 +1784,31 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		final boolean                    switchByteOrder
 	)
 	{
+		return Creator(channelCountProvider, switchByteOrder, false);
+	}
+
+	/**
+	 * Creates a new default {@link BinaryStorer.Creator}.
+	 *
+	 * @param channelCountProvider    supplies the number of channels each created storer will partition its
+	 *                                chunk buffers across.
+	 * @param switchByteOrder         whether persisted values should use a non-native byte order.
+	 * @param captureTrustedObjectIds whether created storers collect the object ids they reference without
+	 *                                storing (see {@link Binary#trustedObjectIds()}) so the persistence
+	 *                                target can validate their existence.
+	 *
+	 * @return the newly created storer creator.
+	 */
+	public static BinaryStorer.Creator Creator(
+		final BinaryChannelCountProvider channelCountProvider   ,
+		final boolean                    switchByteOrder        ,
+		final boolean                    captureTrustedObjectIds
+	)
+	{
 		return new BinaryStorer.Creator.Default(
 			notNull(channelCountProvider),
-			        switchByteOrder
+			        switchByteOrder      ,
+			        captureTrustedObjectIds
 		);
 	}
 
@@ -1703,8 +1863,9 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			////////////////////
 
 
-			private final BinaryChannelCountProvider channelCountProvider;
-			private final boolean                    switchByteOrder     ;
+			private final BinaryChannelCountProvider channelCountProvider   ;
+			private final boolean                    switchByteOrder        ;
+			private final boolean                    captureTrustedObjectIds;
 
 
 
@@ -1717,25 +1878,40 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				final boolean                    switchByteOrder
 			)
 			{
-				super();
-				this.channelCountProvider = channelCountProvider;
-				this.switchByteOrder      = switchByteOrder     ;
+				this(channelCountProvider, switchByteOrder, false);
 			}
 
-			
-			
+			protected Abstract(
+				final BinaryChannelCountProvider channelCountProvider   ,
+				final boolean                    switchByteOrder        ,
+				final boolean                    captureTrustedObjectIds
+			)
+			{
+				super();
+				this.channelCountProvider    = channelCountProvider   ;
+				this.switchByteOrder         = switchByteOrder        ;
+				this.captureTrustedObjectIds = captureTrustedObjectIds;
+			}
+
+
+
 			///////////////////////////////////////////////////////////////////////////
 			// methods //
 			////////////
-			
+
 			protected int channelCount()
 			{
 				return this.channelCountProvider.getChannelCount();
 			}
-			
+
 			protected boolean switchByteOrder()
 			{
 				return this.switchByteOrder;
+			}
+
+			protected boolean captureTrustedObjectIds()
+			{
+				return this.captureTrustedObjectIds;
 			}
 
 		}
@@ -1753,7 +1929,16 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				final boolean                    switchByteOrder
 			)
 			{
-				super(channelCountProvider, switchByteOrder);
+				this(channelCountProvider, switchByteOrder, false);
+			}
+
+			Default(
+				final BinaryChannelCountProvider channelCountProvider   ,
+				final boolean                    switchByteOrder        ,
+				final boolean                    captureTrustedObjectIds
+			)
+			{
+				super(channelCountProvider, switchByteOrder, captureTrustedObjectIds);
 			}
 
 			@Override
@@ -1769,14 +1954,15 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				this.validateIsStoring(target);
 				
 				final BinaryStorer.Default storer = new BinaryStorer.Default(
-					objectManager         ,
-					objectRetriever       ,
-					typeManager           ,
-					target                ,
-					bufferSizeProvider    ,
-					this.channelCount()   ,
-					this.switchByteOrder(),
-					persister
+					objectManager                 ,
+					objectRetriever               ,
+					typeManager                   ,
+					target                        ,
+					bufferSizeProvider            ,
+					this.channelCount()           ,
+					this.switchByteOrder()        ,
+					persister                     ,
+					this.captureTrustedObjectIds()
 				);
 				objectManager.registerLocalRegistry(storer);
 				
@@ -1795,14 +1981,15 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				this.validateIsStoring(target);
 				
 				final BinaryStorer.Eager storer = new BinaryStorer.Eager(
-					objectManager         ,
-					objectRetriever       ,
-					typeManager           ,
-					target                ,
-					bufferSizeProvider    ,
-					this.channelCount()   ,
-					this.switchByteOrder(),
-					persister
+					objectManager                 ,
+					objectRetriever               ,
+					typeManager                   ,
+					target                        ,
+					bufferSizeProvider            ,
+					this.channelCount()           ,
+					this.switchByteOrder()        ,
+					persister                     ,
+					this.captureTrustedObjectIds()
 				);
 				objectManager.registerLocalRegistry(storer);
 				
@@ -1824,16 +2011,17 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				this.validateIsStoring(target);
 
 				final BinaryStorer.Batching storer = new BinaryStorer.Batching(
-					objectManager         ,
-					objectRetriever       ,
-					typeManager           ,
-					target                ,
-					bufferSizeProvider    ,
-					this.channelCount()   ,
-					this.switchByteOrder(),
-					persister             ,
-					controller            ,
-					checkInterval
+					objectManager                 ,
+					objectRetriever               ,
+					typeManager                   ,
+					target                        ,
+					bufferSizeProvider            ,
+					this.channelCount()           ,
+					this.switchByteOrder()        ,
+					persister                     ,
+					controller                    ,
+					checkInterval                 ,
+					this.captureTrustedObjectIds()
 				);
 				objectManager.registerLocalRegistry(storer);
 

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
@@ -781,7 +781,10 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				return null;
 			}
 
-			final Set_long storedObjectIds = Set_long.New();
+			// presized to the item count (upper bound of the chain length) to avoid repeated rehashing.
+			final Set_long storedObjectIds = Set_long.New(
+				XHashing.padHashLength(Math.max((int)this.itemCount, 1))
+			);
 			for(Item e = this.head; (e = e.next) != null;)
 			{
 				if(!isSkipItem(e))

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
@@ -781,9 +781,13 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				return null;
 			}
 
-			// presized to the item count (upper bound of the chain length) to avoid repeated rehashing.
+			/*
+			 * Presized to the exact item chain length to avoid rehashing: pins occupy hash slot
+			 * entries (itemCount) but are never chained, so the chain holds itemCount - pinCount
+			 * entries (skip items are chained but rare; their exclusion below costs no rebuild).
+			 */
 			final Set_long storedObjectIds = Set_long.New(
-				XHashing.padHashLength(Math.max((int)this.itemCount, 1))
+				XHashing.padHashLength(Math.max((int)(this.itemCount - this.pinCount), 1))
 			);
 			for(Item e = this.head; (e = e.next) != null;)
 			{

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectIdRequestor.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectIdRequestor.java
@@ -94,6 +94,9 @@ public interface PersistenceObjectIdRequestor<D>
 	 * instance's object registry entry gets reaped and the storage garbage collector can delete the
 	 * referenced entity while the chunk referencing it is not yet committed, so the commit would persist
 	 * a dangling reference (missing entity on later loads).
+	 * <p>
+	 * Storers may additionally record the object id to have its existence validated by the persistence
+	 * target before the data referencing it is committed (see the trusted-id validation).
 	 *
 	 * @param <T>             the instance type.
 	 * @param objectId        the object id the instance is already registered with.

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectManager.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectManager.java
@@ -324,6 +324,8 @@ extends PersistenceSwizzlingLookup, PersistenceObjectIdHolder, Cloneable<Persist
 					 * can drop its last strong reference between store and commit, the registry's weak entry
 					 * gets reaped and the storage GC deletes the entity while the chunk referencing it is
 					 * not yet committed - the commit would then persist a dangling reference.
+					 * Requestors may also record the id to have its existence validated by the persistence
+					 * target before the data referencing it is committed (trusted-id validation).
 					 */
 					objectIdRequestor.registerSkippedOptional(objectId, object, optionalHandler);
 				}

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceStoreHandler.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceStoreHandler.java
@@ -83,6 +83,19 @@ public interface PersistenceStoreHandler<D> extends PersistenceFunction, Storer
 	public void registerCommitListener(PersistenceCommitListener listener);
 
 	/**
+	 * Reports an object id that this handler writes into the data as a reference without the referenced
+	 * instance being available to be stored in the same commit (e.g. an unloaded {@link org.eclipse.serializer.reference.Lazy}
+	 * reference's cached id). Implementations may record the id to have its existence validated by the
+	 * persistence target before the data referencing it is committed.
+	 *
+	 * @param objectId the referenced object id that is trusted to already exist in the target.
+	 */
+	public default void noteTrustedReference(final long objectId)
+	{
+		// no-op by default
+	}
+
+	/**
 	 * The retriever used to resolve referenced ids when handlers need to read pre-existing data while
 	 * storing.
 	 *


### PR DESCRIPTION
## What this enables

When the lazy storer serializes an object graph, it writes two kinds of references: ids of objects it stores in the same commit (guaranteed to exist afterwards), and ids it merely *trusts* - objects skipped because the persistence context already knows them, and cached ids of unloaded `Lazy` references. If that trust is misplaced (data lost to a crash, a restore from a lagging backup, pre-existing corruption, or a stale cached id), the commit silently persists a reference to nothing. Nothing fails at that moment; the error surfaces at some later load or restart as `StorageExceptionConsistency: No entity found for objectId N`, with no hint of when the dangling reference was written.

This PR makes the storer say which ids those are: it captures every trusted-but-not-stored object id of a commit and attaches the set to the written data. The paired store PR validates them against the entity cache inside the store task - atomically, before anything is written - and, depending on configuration, logs or rejects the store. Silent restart-time corruption becomes an immediate, diagnosable store-time signal.

The recently merged pinning of lazily-skipped instances PREVENTS the main runtime cause on the skip path. This validation is the complementary layer, and for one class of references it is the only mechanism-level protection: type handlers that write a cached object id directly without going through the storer's apply path - `BinaryHandlerLazyDefault` writing an unloaded Lazy's cached id, and any custom handler with the same pattern - create nothing the pin could hold. For those, write-time validation is the actual closure, not merely detection.

## Technical details

  - Capture happens at the two trust points:
    - `registerSkippedOptional` (the global-registry-hit hook the pinning fix introduced) also records the skipped id when capture is enabled;
    - new default no-op `PersistenceStoreHandler.noteTrustedReference(long)`, fired from `BinaryHandlerLazyDefault` when it writes an unloaded Lazy's cached id.
  - Ids are filtered to the data-OID range (type/constant ids resolve at runtime, not via entities) and deduplicated in a storer-local `Set_long` that is `null` when capture is disabled — the feature has zero overhead unless switched on.
  - Commit-time prune: ids that the same commit also STORES are removed before hand-off — an id that is both referenced and stored is guaranteed, not trusted. This keeps the recovery path `storer.storeAll(parent, child)` and eager storers false-positive-free.
  - Transport: a transient `trustedObjectIds` field on `Binary` (set in `commit()` right before `target.write(...)`), so no signature changes anywhere along the write path. Targets that do not know the field simply ignore it.
  - Enabling: a new `captureTrustedObjectIds` flag on the `BinaryStorer.Creator` factory; all existing signatures delegate to `false`. Standalone serializer/communication usage is untouched.

## Scope and pairing

  - Serializer-only, additive; no behavior change unless a creator enables the capture.
  - The paired store PR consumes the set: per-channel validation before write, configurable as `reference-validation = off | log | fail` (default `log`), with the full test suite (registry-trusted skips, unloaded-Lazy cached ids, multi-channel partitioning and rollback, post-failure recovery, GigaMap, batching storers).
  - Must merge before (or together with) the store PR.