### PR TITLE
Clarify docs for HashMapIdObject and Lazy

### DIFF
--- a/base/src/main/java/org/eclipse/serializer/collections/HashMapIdObject.java
+++ b/base/src/main/java/org/eclipse/serializer/collections/HashMapIdObject.java
@@ -25,7 +25,8 @@ import org.eclipse.serializer.typing.KeyValue;
 import java.util.function.Consumer;
 
 /**
- * Primitive (read: fast) synchronized pseudo map implementation that maps long id values to weakly referenced objects.
+ * Primitive (read: fast) pseudo map implementation that maps long id values to strongly referenced objects.
+ * Not thread-safe: concurrent use must be synchronized externally.
  *
  */
 public final class HashMapIdObject<E> implements Sized, Composition

--- a/base/src/main/java/org/eclipse/serializer/reference/Lazy.java
+++ b/base/src/main/java/org/eclipse/serializer/reference/Lazy.java
@@ -70,7 +70,7 @@ public interface Lazy<T> extends UsageMarkable, Referencing<T>
 	 * Clears the reference, leaving the option to reload it again intact, and returns the subject that was
 	 * referenced prior to clearing.
 	 * <p>
-	 * This method should only be used if this lazy reference was stored before, othewise an {@link IllegalStateException} is thrown.
+	 * This method should only be used if this lazy reference was stored before, otherwise an {@link IllegalStateException} is thrown.
 	 * To circumvent this check use {@link #forceClear()} instead.
 	 *
 	 * @return the subject referenced prior to clearing the reference.


### PR DESCRIPTION
Update Javadocs to reflect actual behavior: HashMapIdObject now explicitly documents strong references and lack of thread safety, and Lazy.clear() fixes a typo in its usage warning.