### PR TITLE
Couple healing commits' deferred Lazy $links to the outermost commit's success

### DIFF
--- a/integration-tests/src/test/java/test/eclipse/serializer/danglingref/HealingDeferredLinkTest.java
+++ b/integration-tests/src/test/java/test/eclipse/serializer/danglingref/HealingDeferredLinkTest.java
@@ -1,0 +1,280 @@
+package test.eclipse.serializer.danglingref;
+
+/*-
+ * #%L
+ * Eclipse Serializer Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.serializer.SerializerFoundation;
+import org.eclipse.serializer.collections.types.XGettingCollection;
+import org.eclipse.serializer.persistence.binary.types.Binary;
+import org.eclipse.serializer.persistence.binary.types.BinaryStorer;
+import org.eclipse.serializer.persistence.exceptions.PersistenceDanglingReferences;
+import org.eclipse.serializer.persistence.exceptions.PersistenceException;
+import org.eclipse.serializer.persistence.types.PersistenceIdSet;
+import org.eclipse.serializer.persistence.types.PersistenceManager;
+import org.eclipse.serializer.persistence.types.PersistenceSource;
+import org.eclipse.serializer.persistence.types.PersistenceStorer;
+import org.eclipse.serializer.persistence.types.PersistenceTarget;
+import org.eclipse.serializer.reference.Lazy;
+import org.eclipse.serializer.util.X;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Deferred Lazy linking across healing commits (internal#82): the healing storer's compensating
+ * commit is durable, but its success does not imply the enclosing store's success — the retried
+ * write may still fail terminally. The deferred {@code $link} commit listeners of Lazies the
+ * healing storer serialized must therefore fire only with the OUTERMOST commit's success:
+ * <ul>
+ * <li>retry fails terminally: nothing may have been linked — a linked Lazy over durable-but-
+ * unreachable data would be legally clearable, and once the storage GC reclaims the data, the
+ * cleared reference's cached id is unhealable: permanent loss.</li>
+ * <li>retry succeeds: the transferred listeners fire with the outer commit — the healed subgraph's
+ * fresh Lazies end up properly linked, exactly as if the store had never been rejected.</li>
+ * </ul>
+ * Driven through a scripted {@link PersistenceTarget}, since real storage cannot deterministically
+ * produce "healing commit succeeds, retry fails for an unrelated reason".
+ */
+@Timeout(60)
+public class HealingDeferredLinkTest
+{
+	/** A fabricated object id safely inside the OID range but far above anything assigned here. */
+	static final long FAKE_OID = 1_000_000_000_900_000_082L;
+
+	PersistenceManager<Binary> persistenceManager;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.persistenceManager != null)
+		{
+			this.persistenceManager.close();
+		}
+	}
+
+	private PersistenceStorer createHealingStorer(final ScriptedTarget target)
+	{
+		final PersistenceSource<Binary> source = new PersistenceSource<Binary>()
+		{
+			@Override
+			public XGettingCollection<? extends Binary> read()
+			{
+				return X.empty();
+			}
+
+			@Override
+			public XGettingCollection<? extends Binary> readByObjectIds(final PersistenceIdSet[] oids)
+			{
+				return X.empty();
+			}
+		};
+
+		final SerializerFoundation<?> foundation = SerializerFoundation.New();
+		this.persistenceManager = foundation
+			.setPersistenceSource(source)
+			.setPersistenceTarget(target)
+			.createPersistenceManager()
+		;
+
+		/*
+		 * Bypass PersistenceManager#createStorer: the SerializerFoundation dispatches storers onto
+		 * CLONED object managers (LocalObjectRegistration context dispatching), which would hide
+		 * the test's ghost registration from the storer. The direct creator call wires the
+		 * foundation's shared object manager - the same wiring the embedded storage uses
+		 * (pass-through dispatcher). Single channel, capture + healing enabled: heal-mode wiring.
+		 */
+		return BinaryStorer.Creator(() -> 1, false, true, true).createLazyStorer(
+			foundation.getTypeHandlerManager(),
+			foundation.getObjectManager()     ,
+			this.persistenceManager           ,
+			target                            ,
+			foundation.getBufferSizeProvider(),
+			this.persistenceManager
+		);
+	}
+
+	@Test
+	void lazyStaysUnlinkedWhenRetryFailsAfterSuccessfulHealing()
+	{
+		// write 1 (original store): rejected for the ghost's oid; write 2 (healing commit):
+		// accepted; write 3 (retry): fails for an unrelated reason - terminal.
+		final RuntimeException retryFailure = new RuntimeException("unrelated retry failure (e.g. IO)");
+		final ScriptedTarget   target       = new ScriptedTarget(retryFailure);
+		final PersistenceStorer storer      = this.createHealingStorer(target);
+
+		final Lazy<Payload> freshLazy = Lazy.Reference(new Payload("only in-memory copy"));
+		final Child         ghost     = new Child(freshLazy);
+		this.persistenceManager.objectRegistry().registerObject(FAKE_OID, ghost);
+
+		final Parent parent = new Parent(ghost);
+
+		final RuntimeException thrown = assertThrows(RuntimeException.class, () ->
+		{
+			storer.store(parent);
+			storer.commit();
+		});
+		// precondition: the lazy storer must have skipped the registry-known ghost as a trusted id.
+		assertArrayEquals(new long[]{FAKE_OID}, target.firstWriteTrustedIds,
+			"the original store must reference the ghost as a trusted (skipped) id");
+		assertSame(retryFailure, thrown, "the terminal failure must be the retry's own exception");
+		assertEquals(3, target.writeCount, "expected reject, healing write, failed retry");
+
+		/*
+		 * THE regression pin: the healing commit serialized the ghost's subgraph including the
+		 * fresh Lazy, but its deferred $link must not have fired - the store as a whole failed.
+		 * A linked Lazy here would be clearable while its data is durable-but-unreachable garbage,
+		 * which is the permanent-loss path of internal#82.
+		 */
+		assertFalse(freshLazy.isStored(), "a failed store must leave the healed subgraph's Lazy unlinked");
+		assertThrows(IllegalStateException.class, freshLazy::clear, "an unlinked Lazy may not be clearable");
+	}
+
+	@Test
+	void lazyIsLinkedWhenRetrySucceedsAfterHealing()
+	{
+		// write 1: rejected; write 2 (healing commit): accepted; write 3 (retry): accepted.
+		final ScriptedTarget    target = new ScriptedTarget(null);
+		final PersistenceStorer storer = this.createHealingStorer(target);
+
+		final Lazy<Payload> freshLazy = Lazy.Reference(new Payload("payload"));
+		final Child         ghost     = new Child(freshLazy);
+		this.persistenceManager.objectRegistry().registerObject(FAKE_OID, ghost);
+
+		final Parent parent = new Parent(ghost);
+
+		assertDoesNotThrow(() ->
+		{
+			storer.store(parent);
+			storer.commit();
+		});
+		assertEquals(3, target.writeCount, "expected reject, healing write, successful retry");
+
+		// the transferred listener must have fired with the outer commit's success.
+		assertTrue(freshLazy.isStored(), "a successful store must link the healed subgraph's Lazy");
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// test doubles //
+	/////////////////
+
+	/**
+	 * Rejects the first write reporting {@link #FAKE_OID} missing, accepts the second (the healing
+	 * commit), and fails or accepts the third (the retry) depending on {@code retryFailure}.
+	 */
+	static final class ScriptedTarget implements PersistenceTarget<Binary>
+	{
+		final RuntimeException retryFailure;
+
+		int    writeCount;
+		long[] firstWriteTrustedIds;
+
+		ScriptedTarget(final RuntimeException retryFailure)
+		{
+			super();
+			this.retryFailure = retryFailure;
+		}
+
+		@Override
+		public void write(final Binary data)
+		{
+			if(this.writeCount == 0)
+			{
+				this.firstWriteTrustedIds = data.trustedObjectIds();
+			}
+			switch(++this.writeCount)
+			{
+				case 1:
+					throw new DanglingRejection(FAKE_OID);
+				case 3:
+					if(this.retryFailure != null)
+					{
+						throw this.retryFailure;
+					}
+					// fall through: accepted
+				default:
+					// accepted
+			}
+		}
+
+		@Override
+		public boolean isWritable()
+		{
+			return true;
+		}
+	}
+
+	static final class DanglingRejection extends PersistenceException implements PersistenceDanglingReferences
+	{
+		final long[] missingObjectIds;
+
+		DanglingRejection(final long... missingObjectIds)
+		{
+			super("store references non-existing entities");
+			this.missingObjectIds = missingObjectIds;
+		}
+
+		@Override
+		public long[] missingObjectIds()
+		{
+			return this.missingObjectIds.clone();
+		}
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Parent
+	{
+		public Child child;
+
+		public Parent(final Child child)
+		{
+			super();
+			this.child = child;
+		}
+	}
+
+	public static class Child
+	{
+		public Lazy<Payload> lazy;
+
+		public Child(final Lazy<Payload> lazy)
+		{
+			super();
+			this.lazy = lazy;
+		}
+	}
+
+	public static class Payload
+	{
+		public String data;
+
+		public Payload(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+}

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
@@ -173,6 +173,17 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		private final boolean healDanglingReferences;
 		private final int     healDepth;
 
+		/*
+		 * Where commit listener registrations are routed (null = this storer collects its own).
+		 * Healing storers route to the root storer whose commit they compensate: a healing commit
+		 * is durable, but its success does not imply the enclosing store's success - the retried
+		 * write may still fail terminally. Deferred commit effects (most importantly the Lazy $link
+		 * listeners) must fire only with the OUTERMOST commit's success; firing them from the
+		 * healing commit would link Lazies over durable-but-unreachable data, making them clearable
+		 * and - once the target's GC reclaims that data - their cached ids unhealable: lost objects.
+		 */
+		private final BinaryStorer commitListenerSink;
+
 		private final BulkList<PersistenceCommitListener>  commitListeners = BulkList.New(0);
 		
 		private final BulkList<PersistenceObjectRegistrationListener> persistenceObjectRegistrationListener = BulkList.New(0);
@@ -245,7 +256,8 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				persister              ,
 				captureTrustedObjectIds,
 				false                  ,
-				0
+				0                      ,
+				null
 			);
 		}
 
@@ -260,7 +272,8 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			final Persister                             persister              ,
 			final boolean                               captureTrustedObjectIds,
 			final boolean                               healDanglingReferences ,
-			final int                                   healDepth
+			final int                                   healDepth              ,
+			final BinaryStorer                          commitListenerSink
 		)
 		{
 			super();
@@ -281,6 +294,7 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			;
 			this.healDanglingReferences = healDanglingReferences               ;
 			this.healDepth              = healDepth                            ;
+			this.commitListenerSink     = mayNull(commitListenerSink)          ;
 
 			this.defaultInitialize();
 		}
@@ -699,6 +713,19 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		@Override
 		public void registerCommitListener(final PersistenceCommitListener listener)
 		{
+			/*
+			 * A healing storer's commit is durable, but the store it compensates for may still fail
+			 * terminally on the retried write. Its commit listeners (most importantly the deferred
+			 * Lazy $link registrations) are therefore routed to the root storer and fire only with
+			 * the outermost commit's success - firing them from the healing commit would link Lazies
+			 * over durable-but-unreachable data, making them clearable and, once the target's GC
+			 * reclaims that data, their cached ids unhealable: lost objects.
+			 */
+			if(this.commitListenerSink != null)
+			{
+				this.commitListenerSink.registerCommitListener(listener);
+				return;
+			}
 			this.commitListeners.add(listener);
 		}
 
@@ -723,6 +750,10 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		 *         {@link PersistenceException} stating that the store was committed successfully,
 		 *         with the first listener fault as its cause and any further faults suppressed.
 		 *         {@link #commit()} rethrows it AFTER the storer cleanup.
+		 *         Healing storers never carry local listeners (registrations are routed to the root
+		 *         storer, see {@link #registerCommitListener(PersistenceCommitListener)}), so a
+		 *         listener fault can never masquerade as a healing failure and abort a salvageable
+		 *         retry.
 		 */
 		protected PersistenceException notifyCommitListeners()
 		{
@@ -833,6 +864,18 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		 * target's garbage collection. Unhealable ids (no captured instance, e.g. an unloaded Lazy
 		 * reference's cached id), exhausted attempts/recursion depth or lack of progress rethrow the
 		 * target's original exception.
+		 * <p>
+		 * Deferred commit effects are coupled to the OUTERMOST commit's outcome, not the healing
+		 * commit's: a healing storer routes its commit listener registrations (most importantly the
+		 * deferred Lazy {@code $link}s of the healed subgraph) to the root storer - see
+		 * {@link #registerCommitListener(PersistenceCommitListener)}. Consequently a healing commit
+		 * itself never carries local listeners, so it cannot fail with a post-durability listener
+		 * fault that would falsely abort a salvageable retry. The healing commit's object registry
+		 * merge, in contrast, is deliberately immediate: after a terminal failure it leaves
+		 * associations to the unreachable healed entities behind, which is benign - registry
+		 * knowledge alone makes no Lazy clearable, and a later store that trusts such an id either
+		 * finds the data still present or gets rejected and heals it again from the re-captured
+		 * instance.
 		 */
 		private void writeToTarget(final Binary writeData, final ChunksBuffer[] chunks)
 		{
@@ -957,7 +1000,10 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				this.persister            ,
 				true                      , // capture: transitive dangling references must be healable too
 				true                      , // heal recursively
-				this.healDepth + 1
+				this.healDepth + 1        ,
+				// route commit listeners to the ROOT storer (transitive healing flattens to the same
+				// root), so deferred effects fire only with the outermost commit's success.
+				this.commitListenerSink != null ? this.commitListenerSink : this
 			);
 			this.objectManager.registerLocalRegistry(healingStorer);
 
@@ -1004,7 +1050,7 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		 */
 		private long[] synchYieldTrustedObjectIds()
 		{
-			if(this.trustedObjectIds == null || this.trustedObjectIds.size() == 0)
+			if(this.trustedObjectIds == null || this.trustedObjectIds.isEmpty())
 			{
 				return null;
 			}
@@ -1399,7 +1445,7 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			 * - handle all registered graph objects recursively (but transformed to an iteration).
 			 * Note that this is NOT the same as apply, which does NOT store if the instance is already registry-known.
 			 */
-			long rootOid;
+			final long rootOid;
 			if(Swizzling.isFoundId(rootOid = this.lookupOid(root)))
 			{
 				return rootOid;
@@ -1547,7 +1593,8 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				persister              ,
 				captureTrustedObjectIds,
 				healDanglingReferences ,
-				0
+				0                      ,
+				null
 			);
 		}
 		
@@ -1664,7 +1711,8 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				persister              ,
 				captureTrustedObjectIds,
 				healDanglingReferences ,
-				0
+				0                      ,
+				null
 			);
 			this.controller = notNull(controller);
 
@@ -2290,10 +2338,11 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 					persister                     ,
 					this.captureTrustedObjectIds(),
 					this.healDanglingReferences() ,
-					0
+					0                             ,
+					null
 				);
 				objectManager.registerLocalRegistry(storer);
-				
+
 				return storer;
 			}
 			@Override

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
@@ -182,7 +182,7 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 		 * healing commit would link Lazies over durable-but-unreachable data, making them clearable
 		 * and - once the target's GC reclaims that data - their cached ids unhealable: lost objects.
 		 */
-		private final BinaryStorer commitListenerSink;
+		private final Storer commitListenerSink;
 
 		private final BulkList<PersistenceCommitListener>  commitListeners = BulkList.New(0);
 		
@@ -273,7 +273,7 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			final boolean                               captureTrustedObjectIds,
 			final boolean                               healDanglingReferences ,
 			final int                                   healDepth              ,
-			final BinaryStorer                          commitListenerSink
+			final Storer                                commitListenerSink
 		)
 		{
 			super();


### PR DESCRIPTION
## Summary

Fixes a cross-fix interaction between the dangling-reference self-healing (#294) and the deferred post-commit Lazy linking (#290): the healing storer's compensating commit fired the deferred `$link` commit listeners of every Lazy it serialized — although the enclosing store's retried write can still fail terminally.

A Lazy linked over durable-but-unreachable data is legally clearable (the `isUsed()` eviction guard of #292 covers only used-marked references). Once the `LazyReferenceManager` clears it and the target's GC reclaims the unreachable healed data, a later re-store captures the cached id with a null instance — unhealable, **permanent loss**. The path arms with `reference-validation = heal` ([store#742](https://github.com/eclipse-store/store/pull/742)), so **this PR must merge before or together with store#742**.

## Fix

Healing storers now route `registerCommitListener` to the **root storer** whose commit they compensate (transitive healing flattens to the same root): deferred effects fire exactly when the outermost commit succeeds.

- **Retry succeeds:** the healed subgraph's Lazies end up properly linked with the outer commit — as if the store had never been rejected.
- **Retry fails terminally:** nothing was ever linked, so nothing becomes clearable and no data can be lost.

Two design consequences, both documented in the code:

- A healing commit never carries local listeners, so a post-durability listener fault can no longer masquerade as a healing failure and abort a salvageable retry (the "related" finding of internal#82) — that path is structurally unreachable now (see `notifyCommitListeners`).
- The healing commit's object registry merge stays immediate. Its residue after a terminal failure (associations to unreachable healed entities) is benign and self-rescuing: registry knowledge alone makes no Lazy clearable, and a later store trusting such an id either finds the data still present or gets rejected and heals it again from the re-captured instance (see `writeToTarget`).

## Test

`HealingDeferredLinkTest` drives the exact sequence through a scripted `PersistenceTarget` (reject → healing write accepted → retry fails / succeeds), which real storage cannot produce deterministically (channel problem surfacing is racy; a single channel reports all missing ids in one rejection, aborting healing before any healing commit):

- **Failed retry (the regression pin):** the store fails with the retry's own exception and the healed subgraph's fresh Lazy stays unlinked and unclearable. Red on the unfixed code (the Lazy was linked), green with the fix.
- **Successful retry:** the transferred `$link` fires with the outer commit; the Lazy is linked.

The store-side success-path companion (`HealedSubgraphLazyTest`, end-to-end through real storage in heal mode) is part of store#742.