### PR TITLE
Publish loader-built instances to the object registry only after complete

### DIFF
--- a/integration-tests/src/test/java/org/eclipse/serializer/PassThroughSerializerFoundation.java
+++ b/integration-tests/src/test/java/org/eclipse/serializer/PassThroughSerializerFoundation.java
@@ -1,0 +1,48 @@
+package org.eclipse.serializer;
+
+/*-
+ * #%L
+ * Eclipse Serializer Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.serializer.persistence.binary.types.Binary;
+import org.eclipse.serializer.persistence.types.PersistenceContextDispatcher;
+
+/**
+ * Test fixture: a {@link SerializerFoundation} with the pass-through context dispatcher
+ * instead of the serializer's default {@link PersistenceContextDispatcher.LocalObjectRegistration}.
+ * <p>
+ * With pass-through dispatching, loaders and storers operate directly on the manager's
+ * shared global object registry — the wiring the embedded storage uses. This allows
+ * integration-testing the loader's registry-visibility semantics without a storage backend.
+ * ({@code SerializerFoundation#setContextDispatcher} is intentionally unsupported, hence
+ * this same-package subclass overriding the {@code ensure~} default.)
+ */
+public final class PassThroughSerializerFoundation
+extends SerializerFoundation.Default<PassThroughSerializerFoundation>
+{
+	public static PassThroughSerializerFoundation New()
+	{
+		return new PassThroughSerializerFoundation();
+	}
+
+	private PassThroughSerializerFoundation()
+	{
+		super();
+	}
+
+	@Override
+	protected PersistenceContextDispatcher<Binary> ensureContextDispatcher()
+	{
+		return PersistenceContextDispatcher.PassThrough();
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/serializer/loading/DeferredRegistryPublicationTest.java
+++ b/integration-tests/src/test/java/test/eclipse/serializer/loading/DeferredRegistryPublicationTest.java
@@ -1,0 +1,328 @@
+package test.eclipse.serializer.loading;
+
+/*-
+ * #%L
+ * Eclipse Serializer Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.serializer.PassThroughSerializerFoundation;
+import org.eclipse.serializer.SerializerFoundation;
+import org.eclipse.serializer.collections.BulkList;
+import org.eclipse.serializer.collections.types.XGettingCollection;
+import org.eclipse.serializer.memory.XMemory;
+import org.eclipse.serializer.persistence.binary.types.Binary;
+import org.eclipse.serializer.persistence.binary.types.BinaryField;
+import org.eclipse.serializer.persistence.binary.types.ChunksWrapper;
+import org.eclipse.serializer.persistence.binary.types.CustomBinaryHandler;
+import org.eclipse.serializer.persistence.types.PersistenceIdSet;
+import org.eclipse.serializer.persistence.types.PersistenceLoadHandler;
+import org.eclipse.serializer.persistence.types.PersistenceManager;
+import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.serializer.persistence.types.PersistenceSource;
+import org.eclipse.serializer.persistence.types.PersistenceTarget;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Pins the object-registry publication point of {@code BinaryLoader} (internal issue #72):
+ * a locally created instance may be registered in the global object registry only AFTER the
+ * build's {@code complete} phase, because until then it is not in a consistent state and
+ * lock-free readers ({@code PersistenceManager#lookupObject},
+ * {@code DefaultObjectRegistry#lookupObject}) would observe a blank instance.
+ * <p>
+ * Setup: a {@link PersistenceManager} with a recording {@link PersistenceTarget} and a
+ * replaying {@link PersistenceSource} (the recorded chunks are copied, mirroring a real
+ * write/read round trip), wired with the pass-through context dispatcher — the same wiring
+ * the embedded storage uses, where loaders operate directly on the manager's global registry.
+ * Storing, clearing the registry, and loading again forces the loader down the
+ * "create new instance" path for known object ids.
+ */
+@Timeout(60)
+public class DeferredRegistryPublicationTest
+{
+	PersistenceManager<Binary> persistenceManager;
+
+	final BulkList<Binary> recordedChunks = BulkList.New();
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.persistenceManager != null)
+		{
+			this.persistenceManager.close();
+		}
+	}
+
+	private PersistenceManager<Binary> createPersistenceManager(final ProbeHandler probeHandler)
+	{
+		final PersistenceTarget<Binary> target = new PersistenceTarget<Binary>()
+		{
+			@Override
+			public void write(final Binary data)
+			{
+				/*
+				 * Copy the written buffers instead of aliasing them: mirrors a real storage
+				 * write/read round trip and guards against later buffer reuse by the storer.
+				 */
+				final ByteBuffer[] buffers = data.buffers();
+				final ByteBuffer[] copies  = new ByteBuffer[buffers.length];
+				for(int i = 0; i < buffers.length; i++)
+				{
+					final ByteBuffer source = buffers[i].duplicate();
+					final ByteBuffer copy   = XMemory.allocateDirectNative(source.remaining());
+					copy.put(source);
+					copy.flip();
+					copies[i] = copy;
+				}
+				DeferredRegistryPublicationTest.this.recordedChunks.add(ChunksWrapper.New(copies));
+			}
+
+			@Override
+			public boolean isWritable()
+			{
+				return true;
+			}
+		};
+
+		final PersistenceSource<Binary> source = new PersistenceSource<Binary>()
+		{
+			@Override
+			public XGettingCollection<? extends Binary> read()
+			{
+				return DeferredRegistryPublicationTest.this.recordedChunks;
+			}
+
+			@Override
+			public XGettingCollection<? extends Binary> readByObjectIds(final PersistenceIdSet[] oids)
+			{
+				// replay everything; the loader picks what it needs via its build items.
+				return DeferredRegistryPublicationTest.this.recordedChunks;
+			}
+		};
+
+		final SerializerFoundation<?> foundation = PassThroughSerializerFoundation.New()
+			.setPersistenceSource(source)
+			.setPersistenceTarget(target)
+		;
+		if(probeHandler != null)
+		{
+			foundation.registerCustomTypeHandler(probeHandler);
+		}
+
+		return this.persistenceManager = foundation.createPersistenceManager();
+	}
+
+	/**
+	 * Deterministic publication-point pin, no threads involved: a custom type handler
+	 * checks from within the loader's own {@code initializeState} and {@code complete}
+	 * phases that the instance under construction is NOT yet visible in the global
+	 * object registry, and the test checks that it IS visible right after the load.
+	 */
+	@Test
+	void instanceIsPublishedToTheRegistryOnlyAfterComplete()
+	{
+		final ProbeHandler               probeHandler = new ProbeHandler();
+		final PersistenceManager<Binary> manager      = this.createPersistenceManager(probeHandler);
+		final PersistenceObjectRegistry  registry     = manager.objectRegistry();
+
+		final Probe probe    = new Probe("payload");
+		final long  probeOid = manager.store(probe);
+		assertSame(probe, registry.lookupObject(probeOid), "stored instance must be registered");
+
+		// simulate a fresh session: the data exists only in the recorded chunks.
+		registry.clear();
+		assertNull(registry.lookupObject(probeOid), "probe must not be registered after registry clear");
+
+		probeHandler.armObservation(registry, probeOid);
+
+		final Object reloaded = manager.getObject(probeOid);
+
+		assertNotNull(reloaded);
+		assertNotSame(probe, reloaded, "a new instance must have been created");
+		assertEquals("payload", ((Probe)reloaded).getValue(), "reloaded state must be complete");
+
+		assertEquals(Boolean.FALSE, probeHandler.registeredDuringInitialize,
+			"the instance under construction must not be registry-visible during initializeState");
+		assertEquals(Boolean.FALSE, probeHandler.registeredDuringComplete,
+			"the instance under construction must not be registry-visible entering complete");
+		assertSame(reloaded, registry.lookupObject(probeOid),
+			"the fully built instance must be registered after the load");
+		assertSame(reloaded, manager.getObject(probeOid),
+			"a subsequent load must resolve to the registered instance");
+	}
+
+	/**
+	 * Threaded race regression (the issue's scenario at serializer level): a concurrent
+	 * reader spinning on the lock-free {@code PersistenceManager#lookupObject} must never
+	 * observe a partially initialized instance. JDK hash collections are populated in the
+	 * loader's {@code complete} phase, so before the fix the reader reliably saw the map
+	 * blank (size 0) the moment it was registered.
+	 */
+	@Test
+	void concurrentReaderMustNeverObserveABlankInstance() throws Exception
+	{
+		final int MAP_SIZE = 100_000;
+
+		final PersistenceManager<Binary> manager  = this.createPersistenceManager(null);
+		final PersistenceObjectRegistry  registry = manager.objectRegistry();
+
+		final HashMap<String, String> map = new HashMap<>();
+		for(int i = 0; i < MAP_SIZE; i++)
+		{
+			map.put("key-" + i, "value-" + i);
+		}
+		manager.store(map);
+		final long mapOid = registry.lookupObjectId(map);
+
+		// simulate a fresh session: the data exists only in the recorded chunks.
+		registry.clear();
+		assertNull(registry.lookupObject(mapOid), "map must not be registered after registry clear");
+
+		final AtomicReference<Integer>   firstObservedSize = new AtomicReference<>();
+		final AtomicReference<Throwable> readerFailure     = new AtomicReference<>();
+		final Thread reader = new Thread(() ->
+		{
+			try
+			{
+				Object o;
+				while((o = manager.lookupObject(mapOid)) == null)
+				{
+					Thread.onSpinWait();
+				}
+				firstObservedSize.set(((Map<?, ?>)o).size());
+			}
+			catch(final Throwable t)
+			{
+				readerFailure.set(t);
+			}
+		}, "concurrent-reader");
+		reader.start();
+
+		final Object reloaded = manager.getObject(mapOid);
+		assertEquals(MAP_SIZE, ((Map<?, ?>)reloaded).size(), "loader thread itself must see the complete map");
+
+		reader.join(TimeUnit.SECONDS.toMillis(30));
+		assertFalse(reader.isAlive(), "reader thread must have observed the registered instance");
+		if(readerFailure.get() != null)
+		{
+			fail("reader thread failed", readerFailure.get());
+		}
+
+		assertEquals(MAP_SIZE, firstObservedSize.get().intValue(),
+			"concurrent reader must never observe a partially initialized instance");
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// test doubles //
+	/////////////////
+
+	/**
+	 * Observes from within the loader's build phases whether the instance under
+	 * construction is (wrongly) already visible in the global object registry.
+	 * Same-thread registry lookups are safe here: the registry guards its tables
+	 * with an internal mutex, not the build monitor.
+	 */
+	static final class ProbeHandler extends CustomBinaryHandler<Probe>
+	{
+		private final BinaryField<Probe> value = Field(String.class, Probe::getValue, Probe::setValue);
+
+		private PersistenceObjectRegistry registry     ;
+		private long                      probeObjectId;
+
+		Boolean registeredDuringInitialize;
+		Boolean registeredDuringComplete  ;
+
+		ProbeHandler()
+		{
+			super(Probe.class);
+		}
+
+		void armObservation(final PersistenceObjectRegistry registry, final long probeObjectId)
+		{
+			this.registry      = registry     ;
+			this.probeObjectId = probeObjectId;
+		}
+
+		private boolean isProbeRegistered()
+		{
+			return this.registry.lookupObject(this.probeObjectId) != null;
+		}
+
+		@Override
+		protected Probe instantiate(final Binary data)
+		{
+			return new Probe(null);
+		}
+
+		@Override
+		public void initializeState(final Binary data, final Probe instance, final PersistenceLoadHandler handler)
+		{
+			if(this.registry != null)
+			{
+				this.registeredDuringInitialize = this.isProbeRegistered();
+			}
+			super.initializeState(data, instance, handler);
+		}
+
+		@Override
+		public void complete(final Binary data, final Probe instance, final PersistenceLoadHandler handler)
+		{
+			if(this.registry != null)
+			{
+				this.registeredDuringComplete = this.isProbeRegistered();
+			}
+			super.complete(data, instance, handler);
+		}
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Probe
+	{
+		String value;
+
+		public Probe(final String value)
+		{
+			super();
+			this.value = value;
+		}
+
+		public String getValue()
+		{
+			return this.value;
+		}
+
+		public void setValue(final String value)
+		{
+			this.value = value;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/serializer/loading/DeferredRegistryPublicationTest.java
+++ b/integration-tests/src/test/java/test/eclipse/serializer/loading/DeferredRegistryPublicationTest.java
@@ -75,6 +75,17 @@ public class DeferredRegistryPublicationTest
 		{
 			this.persistenceManager.close();
 		}
+
+		// the copied chunk buffers are test-owned: release them explicitly instead of
+		// relying on GC/cleaner timing for direct memory.
+		for(final Binary chunk : this.recordedChunks)
+		{
+			for(final ByteBuffer buffer : chunk.buffers())
+			{
+				XMemory.deallocateDirectByteBuffer(buffer);
+			}
+		}
+		this.recordedChunks.clear();
 	}
 
 	private PersistenceManager<Binary> createPersistenceManager(final ProbeHandler probeHandler)

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryLoader.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryLoader.java
@@ -26,6 +26,7 @@ import org.eclipse.serializer.math.XMath;
 import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.serializer.persistence.binary.exceptions.BinaryPersistenceException;
 import org.eclipse.serializer.persistence.binary.org.eclipse.serializer.collections.BinaryHandlerSingleton;
+import org.eclipse.serializer.persistence.exceptions.PersistenceExceptionConsistencyObject;
 import org.eclipse.serializer.persistence.exceptions.PersistenceExceptionTypeHandlerConsistencyUnhandledTypeId;
 import org.eclipse.serializer.persistence.types.*;
 import org.eclipse.serializer.util.logging.Logging;
@@ -282,71 +283,23 @@ public interface BinaryLoader extends PersistenceLoader, PersistenceLoadHandler
 
 		private Object getEffectiveInstance(final BinaryLoadItem entry)
 		{
-			/* tricky concurrent part:
-			 * if a proper existing instance already was registered, simply use that.
+			/* if a proper existing instance already was registered, simply use that.
 			 *
-			 * Otherwise:
-			 * try to register the thread-locally created instance as the context instance for the OID at this point and in
-			 * the process use a meanwhile created and registered context instance instead and ignore the own local one
-			 *
-			 * This way, every thread will use the same instance for a given OID even if multiple threads
-			 * are loading and creating different instances for the same OID concurrently.
-			 * The only requirement is that the registry's register method is thread-safe.
-			 *
-			 * Note that the context field is still a thread-local field, just one that points to an instance
-			 * known by the context. The only true multi-thread-ly used part is the context itself.
+			 * Otherwise, the locally created instance becomes the effective instance for this
+			 * build, but it is NOT published to the object registry here: a freshly created
+			 * instance is not in a consistent state until after #update or even after #complete,
+			 * so registering it at this point would expose a blank instance to concurrent
+			 * lock-free readers (e.g. PersistenceManager#lookupObject). Publication is deferred
+			 * to #registerBuiltInstances, which runs after #completeInstances. Intra-build
+			 * references resolve via the loader-local build items map (#getBuildInstance), so
+			 * the graph is wired correctly regardless.
+			 * (This resolves the long-standing "not safe" TODO that used to live here.)
 			 *
 			 * Note on instance type: both ways that set instances here (local and context),
 			 * namely registry and type handler, are trusted to provide (instantiate or know) instances of the
 			 * correct type.
 			 */
 			
-			/* (03.09.2019 TM)TODO: priv#141: existingInstance and createdInstance redundant?
-			 * Aren't these two unnecessary?
-			 * ExistingInstance is a potentially already existing one.
-			 * CreatedInstance is a preliminarily created instance that might be discarded in preference of a
-			 * meanwhile created instance (which is kind of a race condition, isn't it?).
-			 * 
-			 * This could be consolidated to a single "instance" field with the following logic:
-			 * - initially null
-			 * - in here, a "this.registry.ensureInstance(entry, this)" is called that either returns the existing
-			 *   instance or creates a new instance under the protection of its internal lock.
-			 * - the entry would have to implement a proper interface of course. The implementation of its method
-			 *   does what currently is "buildItem.handler.create(buildItem, this);"
-			 *   Something like "this.handler.create(this, loader);"
-			 * 
-			 * This way, there would be only one instance, no discarded preliminary instance and precisely one point
-			 * in time where the proper instance is (selected) or (created and registered).
-			 * 
-			 * (11.11.2019 TM)NOTE:
-			 * Not a good idea. The concept of the two instances was:
-			 * If a new instance has to be created, it is not in a consistent state until after #update
-			 * oder even after #complete. Until then, it may not be publicly available via the object registry.
-			 * Funnily, this code does exactly that, nonetheless:
-			 * - new instance instance is created locally (safe)
-			 * - new instance gets registered in the object Registry (not safe)
-			 * - THEN it gets updated
-			 * - And completed even later.
-			 * 
-			 * Hm.
-			 * So either the concept can/must be changed to
-			 * "a single and early registered instance is okay because it is the application logic's concurrency responsibility"
-			 * (a little shady)
-			 * OR the registration process must be shifted to behind complete or at least to behind update.
-			 * 
-			 * The point below did already handle that.
-			 * 
-			 * Addon to the point above
-			 * Albeit: what about globally registering an instance before it is completely built?
-			 * Couldn't that cause race conditions and inconsistencies?
-			 * And if not: Why not determine (select or created&register) the instance right away when creating
-			 * the build item? Maybe the whole process of created all required build items should happen under
-			 * one big lock of the objectRegistry?
-			 * 
-			 * This would all have to be thought through, researched and tested with the appropriate time and care
-			 * which, currently, is not available.
-			 */
-
 			// (26.08.2019 TM)NOTE: paradigm change: #create may return null. Required for handling deleted enums.
 			if(entry.existingInstance != null)
 			{
@@ -357,11 +310,22 @@ public interface BinaryLoader extends PersistenceLoader, PersistenceLoadHandler
 				return null;
 			}
 			
-			// this makes the locally created instance the "officially existing" instance for the registry's context.
-			return entry.existingInstance = this.objectRegistry.optionalRegisterObject(
-				entry.getBuildItemObjectId(),
-				entry.createdInstance
-			);
+			/*
+			 * An instance may have been registered since build item creation by the loading
+			 * thread itself, e.g. the legacy roots path BinaryHandlerPersistenceRootsDefault
+			 * #updateState registering resolved root/constant instances mid-build. Such an
+			 * instance takes precedence and gets updated; the local blank one is discarded.
+			 * (This relies on the roots build item always being the first in the build chain,
+			 * see #readLoadOnce, so its #updateState runs before any other item is resolved.)
+			 */
+			final Object registeredInstance = this.objectRegistry.lookupObject(entry.getBuildItemObjectId());
+			if(registeredInstance != null)
+			{
+				return entry.existingInstance = registeredInstance;
+			}
+
+			// the locally created instance becomes the effective instance for this build.
+			return entry.existingInstance = entry.createdInstance;
 		}
 
 		protected void loadReferences(final BinaryLoadItem entry)
@@ -440,6 +404,46 @@ public interface BinaryLoader extends PersistenceLoader, PersistenceLoadHandler
 		{
 			this.buildInstances();
 			this.completeInstances();
+			this.registerBuiltInstances();
+		}
+
+		private void registerBuiltInstances()
+		{
+			/*
+			 * Only after #complete are locally created instances fully built (e.g. hash
+			 * collections get their contents only in #complete), so only now may they be
+			 * published to the object registry for other threads to see. See the note in
+			 * #getEffectiveInstance.
+			 */
+			for(BinaryLoadItem entry = this.buildItemsHead.next; entry != null; entry = entry.next)
+			{
+				if(entry.createdInstance == null || entry.existingInstance != entry.createdInstance)
+				{
+					// skip items, pre-existing / meanwhile-registered instances, deleted enums.
+					continue;
+				}
+
+				final Object registered = this.objectRegistry.optionalRegisterObject(
+					entry.getBuildItemObjectId(),
+					entry.createdInstance
+				);
+				if(registered != entry.createdInstance)
+				{
+					/*
+					 * Cannot happen for legit paths: the entire build holds the objectRegistry
+					 * monitor, all legit registry mutations run under that same monitor, and
+					 * mid-build registrations by the loading thread itself are picked up by
+					 * #getEffectiveInstance. Reaching here means a competing instance was
+					 * registered for an objectId whose locally created instance is already
+					 * wired into the built graph - a hard consistency error.
+					 */
+					throw new PersistenceExceptionConsistencyObject(
+						entry.getBuildItemObjectId(),
+						registered,
+						entry.createdInstance
+					);
+				}
+			}
 		}
 
 		private void buildInstances()

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryLoader.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryLoader.java
@@ -287,9 +287,10 @@ public interface BinaryLoader extends PersistenceLoader, PersistenceLoadHandler
 			 *
 			 * Otherwise, the locally created instance becomes the effective instance for this
 			 * build, but it is NOT published to the object registry here: a freshly created
-			 * instance is not in a consistent state until after #update or even after #complete,
-			 * so registering it at this point would expose a blank instance to concurrent
-			 * lock-free readers (e.g. PersistenceManager#lookupObject). Publication is deferred
+			 * instance is not in a consistent state until after the handler's #initializeState
+			 * or even only after its #complete (e.g. hash collections), so registering it at
+			 * this point would expose a blank instance to concurrent lock-free readers
+			 * (e.g. PersistenceManager#lookupObject). Publication is deferred
 			 * to #registerBuiltInstances, which runs after #completeInstances. Intra-build
 			 * references resolve via the loader-local build items map (#getBuildInstance), so
 			 * the graph is wired correctly regardless.


### PR DESCRIPTION
## Problem

`BinaryLoader` registered a freshly created instance in the global object registry before initializing its state: `getEffectiveInstance` called `optionalRegisterObject` at the start of the build, while `initializeState` ran later and JDK hash collections receive their contents only in the `complete` phase. The build holds the registry-instance monitor, but the hot read paths do not: `PersistenceManager.lookupObject` and `DefaultObjectRegistry.lookupObject` guard only with the registry's internal mutex. A concurrent reader could therefore observe a blank instance — an empty collection, or a Lazy whose loader is still null and NPEs on `get()` — cache it as its Lazy subject, and in the worst case derive new state from the blank object and store it back, overwriting the entity's persisted content under its object id. The long-standing in-code TODO explicitly called the early registration "not safe" and already named the fix direction ("the registration process must be shifted to behind complete or at least to behind update").

## Fix

Registration is deferred to a new build phase, `registerBuiltInstances`, which runs after `completeInstances` while still holding the registry monitor. Lock-free readers now see either null or a fully built instance, never an intermediate state. Intra-build reference and cycle resolution is unaffected because it always resolved through the loader-local build items map, never through the registry.

Two deliberate details:

- `getEffectiveInstance` keeps a registry lookup, because the legacy roots path (`BinaryHandlerPersistenceRootsDefault#updateState` → `registerConstant`) legitimately registers resolved root/constant instances mid-build on the loading thread. Such instances take precedence and get updated, exactly as before. This relies on the roots build item always being first in the build chain (see `readLoadOnce`), which is now documented at the lookup.
- If a competing registration for a locally created instance ever appears at publication time — impossible for legitimate paths, which all hold the registry monitor — the loader now throws `PersistenceExceptionConsistencyObject` instead of silently splitting identity. Third-party custom handlers that mutate the registry during `complete` would now get this hard error instead of silent divergence, which is intended.

Fixed as a byproduct: a build that throws no longer leaves blank instances registered (previously they stayed observable until GC'd).

## Tests

`DeferredRegistryPublicationTest` (new, integration-tests): a custom type handler pins deterministically and single-threaded that the instance under construction is not registry-visible during `initializeState` or entering `complete`, but is registered right after the load resolves; a second, threaded test pins that a reader spinning on the lock-free `lookupObject` never observes a partially populated HashMap. The new fixture `PassThroughSerializerFoundation` wires the pass-through context dispatcher — the embedded-storage wiring where loaders share the manager's global registry — which `SerializerFoundation` deliberately does not expose via setter, hence the same-package test subclass.

An end-to-end reproducer through real embedded storage lives in the eclipse-store companion PR; it failed 3/3 runs against the unpatched serializer (reader observed the map at size 0, filling in ~100 ms later) and passes with this fix.

Full serializer suite (all modules plus integration tests) and the full eclipse-store integration suite are green against this change.

Out of scope, pre-existing: the LazyReferenceManager can iterate an inner Lazy before its loader is linked (acknowledged in `BinaryHandlerLazyDefault`); it never calls `get()` and clearing is `isStored()`-gated, so it is unaffected by and orthogonal to this fix.
