### PR TITLE
Add crash evidence logging and artifact upload for tests

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -26,24 +26,3 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         run: mvn -B clean package --file pom.xml
-
-      - name: Dump crash evidence to log
-        if: failure()
-        run: |
-          echo "===== surefire dumpstream / dump files ====="
-          find . -path '*/target/surefire-reports/*' \( -name '*.dumpstream' -o -name '*.dump' \) \
-            -print -exec cat {} \; || true
-          echo "===== JVM fatal error logs (hs_err) ====="
-          find . -name 'hs_err_pid*.log' -print -exec cat {} \; || true
-
-      - name: Upload crash evidence
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: crash-evidence-build
-          path: |
-            **/target/surefire-reports/*.dumpstream
-            **/target/surefire-reports/*.dump
-            **/hs_err_pid*.log
-          if-no-files-found: ignore
-          retention-days: 14

--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -26,3 +26,24 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         run: mvn -B clean package --file pom.xml
+
+      - name: Dump crash evidence to log
+        if: failure()
+        run: |
+          echo "===== surefire dumpstream / dump files ====="
+          find . -path '*/target/surefire-reports/*' \( -name '*.dumpstream' -o -name '*.dump' \) \
+            -print -exec cat {} \; || true
+          echo "===== JVM fatal error logs (hs_err) ====="
+          find . -name 'hs_err_pid*.log' -print -exec cat {} \; || true
+
+      - name: Upload crash evidence
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crash-evidence-build
+          path: |
+            **/target/surefire-reports/*.dumpstream
+            **/target/surefire-reports/*.dump
+            **/hs_err_pid*.log
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/maven_it_test.yml
+++ b/.github/workflows/maven_it_test.yml
@@ -33,6 +33,27 @@ jobs:
       - name: Run integration tests
         run: mvn -P IT -B test -pl integration-tests --file pom.xml -Dgpg.skip=true
 
+      - name: Dump crash evidence to log
+        if: failure()
+        run: |
+          echo "===== surefire dumpstream / dump files ====="
+          find . -path '*/target/surefire-reports/*' \( -name '*.dumpstream' -o -name '*.dump' \) \
+            -print -exec cat {} \; || true
+          echo "===== JVM fatal error logs (hs_err) ====="
+          find . -name 'hs_err_pid*.log' -print -exec cat {} \; || true
+
+      - name: Upload crash evidence
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crash-evidence-integration-tests
+          path: |
+            **/target/surefire-reports/*.dumpstream
+            **/target/surefire-reports/*.dump
+            **/hs_err_pid*.log
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Report JUnit results (dorny - surefire)
         if: always()
         uses: dorny/test-reporter@v2


### PR DESCRIPTION
This pull request adds enhanced crash evidence collection to the Maven integration test workflow. If integration tests fail, the workflow will now dump relevant crash logs to the job log and upload them as artifacts for easier debugging.

Crash evidence collection improvements:

* Added a new step to dump `surefire` dump files and JVM fatal error logs (`hs_err_pid*.log`) to the workflow log if integration tests fail.
* Added a step to upload these crash evidence files as workflow artifacts (`crash-evidence-integration-tests`) for up to 14 days, making it easier to access detailed failure information.