### PR TITLE
fix-power-loss-durability-fsync_74

### DIFF
--- a/afs/afs/src/main/java/org/eclipse/serializer/afs/types/AIoHandler.java
+++ b/afs/afs/src/main/java/org/eclipse/serializer/afs/types/AIoHandler.java
@@ -453,12 +453,19 @@ public interface AIoHandler extends WriteController
 	public long writeBytes(AWritableFile targetFile, Iterable<? extends ByteBuffer> sourceBuffers);
 
 	/**
-	 * Forces all buffered writes of {@code file} to physical storage. No-op for backends that are
-	 * already durable on write acknowledgement.
+	 * Forces all buffered writes of {@code file} to physical storage, including the file's length
+	 * metadata (on file-channel backends, {@link java.nio.channels.FileChannel#force(boolean) force(true)}).
+	 * No-op for backends that are already durable on write acknowledgement.
+	 * <p>
+	 * Default no-op for source/binary backward compatibility; {@link AIoHandler.Abstract} overrides
+	 * this with the validated, locked dispatch to {@code specificSynchronize}.
 	 *
 	 * @param file the writable handle to synchronize.
 	 */
-	public void synchronize(AWritableFile file);
+	public default void synchronize(final AWritableFile file)
+	{
+		// no-op; see AIoHandler.Abstract for the effective implementation
+	}
 
 	/**
 	 * Moves the underlying physical file from {@code sourceFile} to {@code targetFile}, notifying

--- a/afs/afs/src/main/java/org/eclipse/serializer/afs/types/AIoHandler.java
+++ b/afs/afs/src/main/java/org/eclipse/serializer/afs/types/AIoHandler.java
@@ -453,6 +453,14 @@ public interface AIoHandler extends WriteController
 	public long writeBytes(AWritableFile targetFile, Iterable<? extends ByteBuffer> sourceBuffers);
 
 	/**
+	 * Forces all buffered writes of {@code file} to physical storage. No-op for backends that are
+	 * already durable on write acknowledgement.
+	 *
+	 * @param file the writable handle to synchronize.
+	 */
+	public void synchronize(AWritableFile file);
+
+	/**
 	 * Moves the underlying physical file from {@code sourceFile} to {@code targetFile}, notifying
 	 * the relevant {@link AFile.Observer}s and {@link ADirectory.Observer}s.
 	 *
@@ -1419,11 +1427,34 @@ public interface AIoHandler extends WriteController
 				targetFile.iterateObservers(o ->
 					o.onAfterFileWrite(targetFile, sourceBuffers, writeCount)
 				);
-				
+
 				return writeCount;
 			}
 		}
-		
+
+		@Override
+		public void synchronize(final AWritableFile file)
+		{
+			this.validateHandledWritableFile(file);
+
+			synchronized(file.actual())
+			{
+				this.validateIsWritable();
+				this.specificSynchronize(this.typeWritableFile.cast(file));
+			}
+		}
+
+		/**
+		 * No-op by default: a backend with no separate physical write buffer (e.g. a blob store that
+		 * is durable on PUT acknowledgement) needs no barrier. Buffered-write backends override this.
+		 *
+		 * @param file the writable handle to synchronize.
+		 */
+		protected void specificSynchronize(final W file)
+		{
+			// no-op
+		}
+
 		@Override
 		public void moveFile(
 			final AWritableFile sourceFile,

--- a/afs/afs/src/main/java/org/eclipse/serializer/afs/types/AWritableFile.java
+++ b/afs/afs/src/main/java/org/eclipse/serializer/afs/types/AWritableFile.java
@@ -150,6 +150,17 @@ public interface AWritableFile extends AReadableFile
 	}
 
 	/**
+	 * Forces all previously written bytes of this file (and its length metadata) to physical
+	 * storage, i.e. an fsync/{@link java.nio.channels.FileChannel#force(boolean) force} barrier.
+	 * Backends whose write acknowledgement is already durable may implement this as a no-op.
+	 */
+	public default void synchronize()
+	{
+		// synchronization handled by IoHandler.
+		this.actual().fileSystem().ioHandler().synchronize(this);
+	}
+
+	/**
 	 * Creates the underlying physical file. The file must not already exist; use
 	 * {@link #ensureExists()} for create-if-missing semantics.
 	 */

--- a/afs/afs/src/main/java/org/eclipse/serializer/afs/types/AWritableFile.java
+++ b/afs/afs/src/main/java/org/eclipse/serializer/afs/types/AWritableFile.java
@@ -150,9 +150,10 @@ public interface AWritableFile extends AReadableFile
 	}
 
 	/**
-	 * Forces all previously written bytes of this file (and its length metadata) to physical
-	 * storage, i.e. an fsync/{@link java.nio.channels.FileChannel#force(boolean) force} barrier.
-	 * Backends whose write acknowledgement is already durable may implement this as a no-op.
+	 * Forces all previously written bytes of this file to physical storage, i.e. an fsync barrier.
+	 * On file-channel backends this also forces the file's length metadata
+	 * ({@link java.nio.channels.FileChannel#force(boolean) force(true)}). Backends whose write
+	 * acknowledgement is already durable may implement this as a no-op.
 	 */
 	public default void synchronize()
 	{


### PR DESCRIPTION
  afs: add AWritableFile.synchronize() durability barrier

  Introduce an fsync/force primitive on the AFS write layer so callers can
  guarantee that previously written bytes (and the file's length metadata)
  have reached physical storage.

  - AWritableFile.synchronize() default method dispatches to the io-handler.
  - AIoHandler.synchronize(AWritableFile) with an Abstract dispatch impl.
  - AIoHandler.Abstract.specificSynchronize(W) is a concrete no-op: backends that are already durable on write acknowledgement (e.g. blob stores) need no barrier; buffered-write backends override it.

  Additive and backward compatible: the default method and the no-op hook mean
  no existing AWritableFile implementor or AIoHandler backend requires changes.
  Consumed by the storage runtime (see the paired store change).