### PR TITLE
Add missing regression guards for trusted-id capture and XIO.copyFile

### DIFF
--- a/integration-tests/src/test/java/test/eclipse/serializer/danglingref/TrustedObjectIdsCaptureTest.java
+++ b/integration-tests/src/test/java/test/eclipse/serializer/danglingref/TrustedObjectIdsCaptureTest.java
@@ -1,0 +1,228 @@
+package test.eclipse.serializer.danglingref;
+
+/*-
+ * #%L
+ * Eclipse Serializer Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+
+import org.eclipse.serializer.SerializerFoundation;
+import org.eclipse.serializer.collections.types.XGettingCollection;
+import org.eclipse.serializer.persistence.binary.types.Binary;
+import org.eclipse.serializer.persistence.binary.types.BinaryStorer;
+import org.eclipse.serializer.persistence.types.PersistenceIdSet;
+import org.eclipse.serializer.persistence.types.PersistenceManager;
+import org.eclipse.serializer.persistence.types.PersistenceSource;
+import org.eclipse.serializer.persistence.types.PersistenceStorer;
+import org.eclipse.serializer.persistence.types.PersistenceTarget;
+import org.eclipse.serializer.reference.Lazy;
+import org.eclipse.serializer.util.X;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Regression guard for the trusted-object-id capture (the serializer side of the store's
+ * {@code reference-validation} feature): a commit's {@link Binary#trustedObjectIds()} must
+ * contain exactly the object ids the storer wrote as references WITHOUT storing the entity
+ * itself — registry-known skipped instances and unloaded {@code Lazy} references' cached ids —
+ * and must NOT contain ids the same commit stores (referenced-and-stored is guaranteed, not
+ * trusted). With capturing disabled the transport field stays {@code null}.
+ * <p>
+ * The capture feeds the storage-side validation ({@code reference-validation = log|fail|heal});
+ * a silently shrunken or over-eager capture would turn that validation into false negatives
+ * (missed dangling references) or false positives (rejected healthy stores) respectively.
+ */
+@Timeout(60)
+public class TrustedObjectIdsCaptureTest
+{
+	PersistenceManager<Binary> persistenceManager;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.persistenceManager != null)
+		{
+			this.persistenceManager.close();
+		}
+	}
+
+	/**
+	 * Records the Binary handed to the target so the test can inspect the commit's
+	 * trusted-id transport field. Writes always succeed.
+	 */
+	static final class RecordingTarget implements PersistenceTarget<Binary>
+	{
+		Binary lastWrite;
+
+		@Override
+		public void write(final Binary data)
+		{
+			this.lastWrite = data;
+		}
+
+		@Override
+		public boolean isWritable()
+		{
+			return true;
+		}
+	}
+
+	private PersistenceStorer createStorer(final RecordingTarget target, final boolean capture)
+	{
+		final PersistenceSource<Binary> source = new PersistenceSource<Binary>()
+		{
+			@Override
+			public XGettingCollection<? extends Binary> read()
+			{
+				return X.empty();
+			}
+
+			@Override
+			public XGettingCollection<? extends Binary> readByObjectIds(final PersistenceIdSet[] oids)
+			{
+				return X.empty();
+			}
+		};
+
+		final SerializerFoundation<?> foundation = SerializerFoundation.New();
+		this.persistenceManager = foundation
+			.setPersistenceSource(source)
+			.setPersistenceTarget(target)
+			.createPersistenceManager()
+		;
+
+		// direct creator call: wires the foundation's shared object manager, the same
+		// pass-through shape the embedded storage uses (see HealingDeferredLinkTest).
+		return BinaryStorer.Creator(() -> 1, false, capture, false).createLazyStorer(
+			foundation.getTypeHandlerManager(),
+			foundation.getObjectManager()     ,
+			this.persistenceManager           ,
+			target                            ,
+			foundation.getBufferSizeProvider(),
+			this.persistenceManager
+		);
+	}
+
+	private static boolean contains(final long[] ids, final long id)
+	{
+		if(ids == null)
+		{
+			return false;
+		}
+		for(final long candidate : ids)
+		{
+			if(candidate == id)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Test
+	void captureContainsSkippedAndUnloadedLazyIdsButNotStoredIds()
+	{
+		final RecordingTarget   target = new RecordingTarget();
+		final PersistenceStorer storer = this.createStorer(target, true);
+
+		// a registry-known instance the lazy storer will SKIP (trusted):
+		final Child skipped   = new Child("skipped");
+		final long skippedOid = 1_000_000_000_920_000_001L;
+		this.persistenceManager.objectRegistry().registerObject(skippedOid, skipped);
+
+		// an unloaded Lazy: link a loaded reference to its cached oid, then clear it so only
+		// the cached id remains (referent gone = the trusted, unhealable-if-missing class):
+		final long lazyTargetOid = 1_000_000_000_920_000_002L;
+		final Lazy<Child> unloaded = Lazy.UnregisteredReference(new Child("lazy target"));
+		((Lazy.Default<Child>)unloaded).$link(lazyTargetOid, this.persistenceManager);
+		unloaded.clear();
+
+		// a child stored IN the same commit (referenced and stored -> pruned, not trusted):
+		final Child storedChild = new Child("stored");
+
+		final Parent parent = new Parent(skipped, unloaded, storedChild);
+		storer.store(parent);
+		storer.commit();
+
+		assertNotNull(target.lastWrite, "the commit must have written data");
+		final long[] trusted = target.lastWrite.trustedObjectIds();
+		assertNotNull(trusted, "capture enabled: the commit must transport its trusted ids");
+
+		assertTrue(contains(trusted, skippedOid),
+			"a registry-known skipped instance's id must be captured as trusted, got: " + Arrays.toString(trusted));
+		assertTrue(contains(trusted, lazyTargetOid),
+			"an unloaded Lazy's cached id must be captured as trusted, got: " + Arrays.toString(trusted));
+
+		final long storedChildOid = this.persistenceManager.objectRegistry().lookupObjectId(storedChild);
+		assertFalse(contains(trusted, storedChildOid),
+			"an id stored by the same commit is guaranteed, not trusted - it must be pruned, got: "
+				+ Arrays.toString(trusted));
+		final long parentOid = this.persistenceManager.objectRegistry().lookupObjectId(parent);
+		assertFalse(contains(trusted, parentOid),
+			"the stored root itself must never be in the trusted set, got: " + Arrays.toString(trusted));
+	}
+
+	@Test
+	void captureDisabledTransportsNothing()
+	{
+		final RecordingTarget   target = new RecordingTarget();
+		final PersistenceStorer storer = this.createStorer(target, false);
+
+		final Child skipped = new Child("skipped");
+		this.persistenceManager.objectRegistry().registerObject(1_000_000_000_920_000_003L, skipped);
+
+		storer.store(new Parent(skipped, null, new Child("stored")));
+		storer.commit();
+
+		assertNotNull(target.lastWrite, "the commit must have written data");
+		assertNull(target.lastWrite.trustedObjectIds(),
+			"capture disabled: the transport field must stay null (zero overhead contract)");
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Parent
+	{
+		public Child       skipped;
+		public Lazy<Child> lazy   ;
+		public Child       stored ;
+
+		public Parent(final Child skipped, final Lazy<Child> lazy, final Child stored)
+		{
+			super();
+			this.skipped = skipped;
+			this.lazy    = lazy   ;
+			this.stored  = stored ;
+		}
+	}
+
+	public static class Child
+	{
+		public String data;
+
+		public Child(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/serializer/io/XioCopyFileTargetPositionTest.java
+++ b/integration-tests/src/test/java/test/eclipse/serializer/io/XioCopyFileTargetPositionTest.java
@@ -1,0 +1,123 @@
+package test.eclipse.serializer.io;
+
+/*-
+ * #%L
+ * Eclipse Serializer Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.READ;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.serializer.io.XIO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression guard for the {@code XIO.copyFile} target-position overloads (internal issue #69,
+ * originally reproduced in microstream-test):
+ * <ul>
+ * <li>{@code copyFile(source, target, targetPosition)} sized the transfer with
+ * {@code sourceChannel.size()} although {@code transferFrom} consumes from the source's CURRENT
+ * position — with a source not positioned at 0 (the AFS invariant: writable channels are
+ * positioned at the file end), {@code transferFrom} returned 0 forever and the loop never
+ * terminated. Fixed: sized from the current position, zero-progress breaks out.</li>
+ * <li>{@code copyFile(source, target, targetPosition, length)} clamped availability with
+ * {@code sourceChannel.size() - position}, subtracting the TARGET position from the SOURCE size —
+ * mixing up the two cursors. Fixed: clamps with the source's own position.</li>
+ * </ul>
+ * Plain {@link FileChannel}s in a temp directory — no framework wiring. The formerly-hanging case
+ * is guarded by the class-level {@link Timeout}: a regression shows up as a timeout, not a hung build.
+ */
+@Timeout(60)
+public class XioCopyFileTargetPositionTest
+{
+	@TempDir
+	Path tempDir;
+
+	private FileChannel channel(final Path path) throws IOException
+	{
+		return FileChannel.open(path, CREATE, READ, WRITE);
+	}
+
+	@Test
+	void copyFileWithTargetPositionTerminatesAndCopiesFromSourcePosition() throws IOException
+	{
+		final byte[] content = "0123456789".getBytes(StandardCharsets.US_ASCII);
+		final Path sourcePath = this.tempDir.resolve("source.bin");
+		final Path targetPath = this.tempDir.resolve("target.bin");
+		Files.write(sourcePath, content);
+
+		try(FileChannel source = this.channel(sourcePath); FileChannel target = this.channel(targetPath))
+		{
+			// the AFS invariant: a writable channel is positioned at the file END, not 0.
+			source.position(source.size());
+
+			// pre-fix: transferFrom returned 0 forever -> infinite loop (this call never returned).
+			final long copied = XIO.copyFile(source, target, 0L);
+
+			assertEquals(0L, copied,
+				"a source at its end has zero available bytes - the copy must return the short count 0");
+		}
+
+		try(FileChannel source = this.channel(sourcePath); FileChannel target = this.channel(targetPath))
+		{
+			// mid-file source position: only the remainder from the position may be copied.
+			source.position(4);
+			final long copied = XIO.copyFile(source, target, 0L);
+
+			assertEquals(content.length - 4, copied,
+				"the copy must transfer exactly the bytes available from the source's current position");
+			assertArrayEquals("456789".getBytes(StandardCharsets.US_ASCII),
+				Files.readAllBytes(targetPath),
+				"the copied bytes must be the source's remainder from its position");
+		}
+	}
+
+	@Test
+	void copyFileWithTargetPositionAndLengthClampsAgainstTheSourceCursor() throws IOException
+	{
+		final byte[] content = "abcdefghij".getBytes(StandardCharsets.US_ASCII); // 10 bytes
+		final Path sourcePath = this.tempDir.resolve("source2.bin");
+		final Path targetPath = this.tempDir.resolve("target2.bin");
+		Files.write(sourcePath, content);
+		// pre-existing target content so a large targetPosition is within bounds:
+		Files.write(targetPath, new byte[16]);
+
+		try(FileChannel source = this.channel(sourcePath); FileChannel target = this.channel(targetPath))
+		{
+			/*
+			 * targetPosition (12) > source size (10): the pre-fix clamp computed
+			 * size() - targetPosition = -2 available bytes although the whole source
+			 * is readable from its position 0 - the copy was silently skipped short.
+			 */
+			final long copied = XIO.copyFile(source, target, 12L, 4L);
+
+			assertEquals(4L, copied,
+				"availability must be clamped against the SOURCE cursor, not the target position");
+			final byte[] targetBytes = Files.readAllBytes(targetPath);
+			assertArrayEquals("abcd".getBytes(StandardCharsets.US_ASCII),
+				java.util.Arrays.copyOfRange(targetBytes, 12, 16),
+				"the requested range must land at the target position");
+		}
+	}
+}


### PR DESCRIPTION
- TrustedObjectIdsCaptureTest: pins the storer-side trusted-object-id capture (reference-validation transport): registry-known skipped instances and unloaded Lazy cached ids are captured, same-commit stored ids are pruned, disabled capture transports null.
- XioCopyFileTargetPositionTest: pins both copyFile target-position overload fixes (source-cursor availability clamp; zero-progress termination) with plain FileChannels; the formerly-hanging case is timeout-guarded instead of disabled.