### PR TITLE
Adopt canonical constant on publication conflict instead of failing the load

### DIFF
--- a/integration-tests/src/test/java/test/eclipse/serializer/loading/RootsConstantRegistrationConflictTest.java
+++ b/integration-tests/src/test/java/test/eclipse/serializer/loading/RootsConstantRegistrationConflictTest.java
@@ -1,0 +1,242 @@
+package test.eclipse.serializer.loading;
+
+/*-
+ * #%L
+ * Eclipse Serializer Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.nio.ByteBuffer;
+
+import org.eclipse.serializer.PassThroughSerializerFoundation;
+import org.eclipse.serializer.SerializerFoundation;
+import org.eclipse.serializer.collections.BulkList;
+import org.eclipse.serializer.collections.types.XGettingCollection;
+import org.eclipse.serializer.memory.XMemory;
+import org.eclipse.serializer.persistence.binary.types.Binary;
+import org.eclipse.serializer.persistence.binary.types.BinaryField;
+import org.eclipse.serializer.persistence.binary.types.ChunksWrapper;
+import org.eclipse.serializer.persistence.binary.types.CustomBinaryHandler;
+import org.eclipse.serializer.persistence.types.PersistenceIdSet;
+import org.eclipse.serializer.persistence.types.PersistenceLoadHandler;
+import org.eclipse.serializer.persistence.types.PersistenceManager;
+import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.serializer.persistence.types.PersistenceSource;
+import org.eclipse.serializer.persistence.types.PersistenceTarget;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Deterministic regression test for internal issue #87 (a regression from serializer#299 /
+ * issue #72).
+ * <p>
+ * #299 deferred the loader's object-registry publication of freshly built instances to a
+ * post-{@code complete} phase ({@code BinaryLoader#registerBuiltInstances}) and guarded it with a
+ * hard consistency error if a different instance was already registered under an object id. That
+ * guard fired on a legitimate same-thread registration during a roots load: the roots/constants
+ * resolution ({@code BinaryHandlerPersistenceRootsDefault#updateState} →
+ * {@code registerConstant}) registers a canonical constant instance under an object id for which
+ * the loader had already created a provisional local copy while building a sibling that references
+ * it. The storage then failed to start.
+ * <p>
+ * This test reproduces that mechanism without a full storage/roots setup: a custom type handler
+ * registers a canonical constant under its child's object id from within its {@code complete}
+ * phase — exactly the "register during update/complete, after siblings were locally created"
+ * shape — and asserts the load completes and adopts the canonical instance. Against the unpatched
+ * loader it fails with {@code PersistenceExceptionConsistencyObject} from
+ * {@code registerBuiltInstances}.
+ */
+@Timeout(60)
+public class RootsConstantRegistrationConflictTest
+{
+	PersistenceManager<Binary> persistenceManager;
+
+	final BulkList<Binary> recordedChunks = BulkList.New();
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.persistenceManager != null)
+		{
+			this.persistenceManager.close();
+		}
+		for(final Binary chunk : this.recordedChunks)
+		{
+			for(final ByteBuffer buffer : chunk.buffers())
+			{
+				XMemory.deallocateDirectByteBuffer(buffer);
+			}
+		}
+		this.recordedChunks.clear();
+	}
+
+	private PersistenceManager<Binary> createPersistenceManager(final ContainerHandler containerHandler)
+	{
+		final PersistenceTarget<Binary> target = new PersistenceTarget<Binary>()
+		{
+			@Override
+			public void write(final Binary data)
+			{
+				final ByteBuffer[] buffers = data.buffers();
+				final ByteBuffer[] copies  = new ByteBuffer[buffers.length];
+				for(int i = 0; i < buffers.length; i++)
+				{
+					final ByteBuffer source = buffers[i].duplicate();
+					final ByteBuffer copy   = XMemory.allocateDirectNative(source.remaining());
+					copy.put(source);
+					copy.flip();
+					copies[i] = copy;
+				}
+				RootsConstantRegistrationConflictTest.this.recordedChunks.add(ChunksWrapper.New(copies));
+			}
+
+			@Override
+			public boolean isWritable()
+			{
+				return true;
+			}
+		};
+
+		final PersistenceSource<Binary> source = new PersistenceSource<Binary>()
+		{
+			@Override
+			public XGettingCollection<? extends Binary> read()
+			{
+				return RootsConstantRegistrationConflictTest.this.recordedChunks;
+			}
+
+			@Override
+			public XGettingCollection<? extends Binary> readByObjectIds(final PersistenceIdSet[] oids)
+			{
+				return RootsConstantRegistrationConflictTest.this.recordedChunks;
+			}
+		};
+
+		final SerializerFoundation<?> foundation = PassThroughSerializerFoundation.New()
+			.setPersistenceSource(source)
+			.setPersistenceTarget(target)
+		;
+		foundation.registerCustomTypeHandler(containerHandler);
+
+		return this.persistenceManager = foundation.createPersistenceManager();
+	}
+
+	@Test
+	void constantRegisteredDuringCompleteMustNotFailThePublication()
+	{
+		final ContainerHandler           handler  = new ContainerHandler();
+		final PersistenceManager<Binary> manager  = this.createPersistenceManager(handler);
+		final PersistenceObjectRegistry  registry = manager.objectRegistry();
+
+		final Node      child     = new Node("x");
+		final Container container = new Container(child);
+		final long containerOid = manager.store(container);
+		final long childOid     = registry.lookupObjectId(child);
+
+		// fresh session: the graph exists only in the recorded chunks.
+		registry.clear();
+
+		// arm the handler to register a canonical, value-equal-but-distinct child instance under
+		// the child's object id during its complete phase (mimics roots/constants registration).
+		handler.arm(registry);
+
+		final Object reloaded = assertDoesNotThrow(() -> manager.getObject(containerOid),
+			"a same-thread constant registration during the build must not fail the loader's publication");
+
+		assertNotNull(reloaded);
+		final Container reloadedContainer = (Container)reloaded;
+		assertNotNull(reloadedContainer.child, "the child reference must be wired");
+		assertEquals("x", reloadedContainer.child.label, "the child value must be intact");
+
+		assertNotNull(handler.registeredCanonical, "the handler must have registered a canonical child");
+		assertSame(handler.registeredCanonical, registry.lookupObject(childOid),
+			"the loader must adopt the canonical instance registered during the build");
+	}
+
+	///////////////////////////////////////////////////////////////////////////
+	// test doubles //
+	/////////////////
+
+	/**
+	 * A custom handler for {@link Container} that, from within {@link #complete}, registers a
+	 * canonical constant instance under the child's object id — reproducing the shape of the
+	 * roots/constants resolution registering an instance after sibling build items already exist.
+	 */
+	static final class ContainerHandler extends CustomBinaryHandler<Container>
+	{
+		private final BinaryField<Container> child = Field(Node.class, c -> c.child, (c, n) -> c.child = n);
+
+		private PersistenceObjectRegistry registry;
+
+		Node registeredCanonical;
+
+		ContainerHandler()
+		{
+			super(Container.class);
+		}
+
+		void arm(final PersistenceObjectRegistry registry)
+		{
+			this.registry = registry;
+		}
+
+		@Override
+		protected Container instantiate(final Binary data)
+		{
+			return new Container(null);
+		}
+
+		@Override
+		public void complete(final Binary data, final Container instance, final PersistenceLoadHandler handler)
+		{
+			super.complete(data, instance, handler);
+			if(this.registry != null)
+			{
+				// the child reference oid is the single reference in the content, at offset 0.
+				final long childOid = data.read_long(0);
+				this.registeredCanonical = new Node(instance.child.label);
+				this.registry.registerConstant(childOid, this.registeredCanonical);
+			}
+		}
+	}
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Container
+	{
+		Node child;
+
+		public Container(final Node child)
+		{
+			super();
+			this.child = child;
+		}
+	}
+
+	public static class Node
+	{
+		String label;
+
+		public Node(final String label)
+		{
+			super();
+			this.label = label;
+		}
+	}
+}

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryLoader.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryLoader.java
@@ -315,9 +315,11 @@ public interface BinaryLoader extends PersistenceLoader, PersistenceLoadHandler
 			 * An instance may have been registered since build item creation by the loading
 			 * thread itself, e.g. the legacy roots path BinaryHandlerPersistenceRootsDefault
 			 * #updateState registering resolved root/constant instances mid-build. Such an
-			 * instance takes precedence and gets updated; the local blank one is discarded.
-			 * (This relies on the roots build item always being the first in the build chain,
-			 * see #readLoadOnce, so its #updateState runs before any other item is resolved.)
+			 * instance takes precedence and gets updated; the local copy is discarded.
+			 * If the registration instead happens AFTER this item was resolved to its local copy
+			 * (build-chain ordering is not guaranteed to place roots before every referrer of a
+			 * constant), the conflict is reconciled by adopting the registered instance in
+			 * #registerBuiltInstances - see the note there (issue #87).
 			 */
 			final Object registeredInstance = this.objectRegistry.lookupObject(entry.getBuildItemObjectId());
 			if(registeredInstance != null)
@@ -431,18 +433,33 @@ public interface BinaryLoader extends PersistenceLoader, PersistenceLoadHandler
 				if(registered != entry.createdInstance)
 				{
 					/*
-					 * Cannot happen for legit paths: the entire build holds the objectRegistry
-					 * monitor, all legit registry mutations run under that same monitor, and
-					 * mid-build registrations by the loading thread itself are picked up by
-					 * #getEffectiveInstance. Reaching here means a competing instance was
-					 * registered for an objectId whose locally created instance is already
-					 * wired into the built graph - a hard consistency error.
+					 * A different instance is already registered for this objectId. No other thread can
+					 * have registered it: the entire build holds the objectRegistry instance monitor, and
+					 * every registry mutation path (other loaders' builds, the object manager's
+					 * id-ensuring and storer merges, root registration) acquires that same monitor. So the
+					 * registration was made by THIS thread during THIS build.
+					 *
+					 * The only such registration that legitimately targets an objectId this loader also
+					 * built a provisional local copy for is the roots/constants resolution registering a
+					 * canonical CONSTANT (see BinaryHandlerPersistenceRootsDefault#updateState ->
+					 * registerConstant, and the "unnecessarily created instance that gets discarded" note
+					 * in that handler's #create). Constants are canonical and value-equal to the discarded
+					 * local copy, so adopting the registered instance is safe - this is the adoption the
+					 * pre-deferral optionalRegisterObject in #getEffectiveInstance performed implicitly
+					 * (issue #87 regression fix for issue #72 / #299).
+					 *
+					 * Any OTHER (non-constant) competing registration is genuinely unexpected and would
+					 * risk an identity split on a mutable instance, so it remains a hard consistency error.
 					 */
-					throw new PersistenceExceptionConsistencyObject(
-						entry.getBuildItemObjectId(),
-						registered,
-						entry.createdInstance
-					);
+					if(!this.objectRegistry.containsConstant(entry.getBuildItemObjectId()))
+					{
+						throw new PersistenceExceptionConsistencyObject(
+							entry.getBuildItemObjectId(),
+							registered,
+							entry.createdInstance
+						);
+					}
+					entry.existingInstance = registered;
 				}
 			}
 		}

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/DefaultObjectRegistry.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/DefaultObjectRegistry.java
@@ -527,6 +527,32 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
         }
     }
 
+    @Override
+    public boolean containsConstant(final long objectId)
+    {
+        synchronized(this.mutex)
+        {
+            // constants live in the hot registry during normal operation and in the cold-storage
+            // arrays after a clear/truncate cycle; exactly one of the two is populated at a time.
+            if(this.constantsHotRegistry != null)
+            {
+                return this.constantsHotRegistry.get(objectId) != null;
+            }
+            final long[] coldIds = this.constantsColdStorageObjectIds;
+            if(coldIds != null)
+            {
+                for(int i = 0; i < coldIds.length; i++)
+                {
+                    if(coldIds[i] == objectId)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+    }
+
     private boolean synchContainsObjectId(final long objectId)
 	{
 		for(Entry e = this.oidHashTable[(int)objectId & this.hashRange]; e != null; e = e.oidNext)

--- a/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectRegistry.java
+++ b/persistence/persistence/src/main/java/org/eclipse/serializer/persistence/types/PersistenceObjectRegistry.java
@@ -109,6 +109,20 @@ public interface PersistenceObjectRegistry extends PersistenceSwizzlingLookup, C
     public boolean containsClearedObject(long objectId);
 
 	/**
+	 * Whether the passed object id is registered as a <em>constant</em> (see
+	 * {@link #registerConstant(long, Object)}). The default implementation conservatively returns
+	 * {@code false}; {@link DefaultObjectRegistry} reports the actual constant registration.
+	 *
+	 * @param objectId the object id to check.
+	 *
+	 * @return {@code true} if a constant is registered for {@code objectId}.
+	 */
+    public default boolean containsConstant(final long objectId)
+    {
+    	return false;
+    }
+
+	/**
 	 * Iterates every live registered entry, invoking {@code acceptor} once per {@code (objectId, instance)}
 	 * pair.
 	 *


### PR DESCRIPTION
Fixes a regression introduced by #299.

## Problem

#299 deferred the loader's object-registry publication of freshly built instances to a post-`complete` phase (`BinaryLoader.registerBuiltInstances`) and guarded it with a hard `PersistenceExceptionConsistencyObject` if a different instance was already registered under an object id — a case #299 assumed impossible for legitimate paths. It is not. During a roots load, the roots/constants resolution (`BinaryHandlerPersistenceRootsDefault.updateState` → `registerConstant`) legitimately registers a canonical constant instance under an object id for which this same loader had already created a provisional local copy while building a sibling that references it. When `getEffectiveInstance` adopted that local copy before the constant was registered, `registerBuiltInstances` later found a different (value-equal) instance under the object id and threw — so the storage failed to start. This is an availability regression, deterministic on all JDKs; no data is lost or corrupted (both instances are the same value). It surfaced in `vmt_smoke` (the GigaMap + Lucene + JVector travel scenario), red since build 1256; ordinary single-root applications take the safe ordering and are unaffected.

## Why adoption is safe

No other thread can be the source of the conflict: the entire build holds the `objectRegistry` instance monitor, and every registry mutation path — other loaders' builds, the object manager's id-ensuring and storer merges, root registration — acquires that same monitor. So the competing registration was made by this thread during this build. The only legitimate such case is the roots/constants resolution registering a canonical constant, which is canonical and value-equal to the discarded local copy (the "unnecessarily created instance that gets discarded" that the roots handler's own `create()` already anticipates). Adopting it restores the adoption the pre-#299 `optionalRegisterObject` performed implicitly inside `getEffectiveInstance`.

## Fix

`registerBuiltInstances` now adopts the already-registered instance on conflict — but only when it is a registered constant, verified through a new `PersistenceObjectRegistry.containsConstant(long)` query (a `default false` on the interface so no external implementer breaks, implemented in `DefaultObjectRegistry` over its hot/cold constant storage). Any other, non-constant competing registration keeps the hard `PersistenceExceptionConsistencyObject`, because adopting there could silently hide an identity split on a mutable instance rather than a value-equal constant. A direct `getObject(constantOid)` now also resolves to the canonical constant instead of a duplicate. The `getEffectiveInstance` comment that had relied on "the roots build item is always first in the build chain" is corrected — that ordering is not guaranteed (this issue is the counterexample), and the conflict is reconciled at publication instead.

## Tests

`RootsConstantRegistrationConflictTest` (new, integration-tests) reproduces the exact mechanism deterministically without a full storage/roots setup: a custom type handler registers a canonical constant under its child's object id from within its `complete` phase — the "register during complete, after the sibling was locally created" shape — and asserts the load completes and adopts the canonical constant. Against the unpatched loader it throws the same `PersistenceExceptionConsistencyObject` at `registerBuiltInstances` that the issue reports (3 out of 3 runs); with this fix it passes. The microstream-test travel test (`TravelAgencyServiceTest`) remains the end-to-end regression guard.

Full serializer suite (all module unit tests plus integration tests, including the `DefaultObjectRegistry` and roots/legacy coverage) and the full eclipse-store integration suite are green against this change.

## Note on residual behavior

For a constant that is referenced elsewhere in the same load, objects built before the constant is registered keep their local copy while the registry and future loads use the canonical instance. This is confined to in-memory reference identity within that one load and is benign for the instances that actually take this path — canonical constants (JDK empties/comparators, enum-like instances, root-identifier Strings), all immutable and value-equal. Persistence stays consistent: references serialize by object id and the registry maps the id to the canonical instance. The fully divergence-free alternative (front-loading the constants registration before sibling build items are created, so the whole graph references the canonical instance) is more invasive to the load sequence and was deliberately not taken for this regression fix.