### PR TITLE
Add binary type handler for EqConstList

### DIFF
--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/org/eclipse/serializer/collections/BinaryHandlerEqConstList.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/org/eclipse/serializer/collections/BinaryHandlerEqConstList.java
@@ -1,0 +1,158 @@
+package org.eclipse.serializer.persistence.binary.org.eclipse.serializer.collections;
+
+/*-
+ * #%L
+ * Eclipse Serializer Persistence Binary
+ * %%
+ * Copyright (C) 2023 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.lang.reflect.Field;
+
+import org.eclipse.serializer.collections.EqConstList;
+import org.eclipse.serializer.equality.Equalator;
+import org.eclipse.serializer.memory.XMemory;
+import org.eclipse.serializer.persistence.binary.types.AbstractBinaryHandlerCustomCollection;
+import org.eclipse.serializer.persistence.binary.types.Binary;
+import org.eclipse.serializer.persistence.types.Persistence;
+import org.eclipse.serializer.persistence.types.PersistenceFunction;
+import org.eclipse.serializer.persistence.types.PersistenceLoadHandler;
+import org.eclipse.serializer.persistence.types.PersistenceReferenceLoader;
+import org.eclipse.serializer.persistence.types.PersistenceStoreHandler;
+import org.eclipse.serializer.util.X;
+
+
+public final class BinaryHandlerEqConstList
+extends AbstractBinaryHandlerCustomCollection<EqConstList<?>>
+{
+	///////////////////////////////////////////////////////////////////////////
+	// constants //
+	//////////////
+
+	// one oid for equalator reference as leading header value
+	static final long BINARY_OFFSET_EQUALATOR =                                                     0;
+	// the simple element list follows the equalator header
+	static final long BINARY_OFFSET_LIST      = BINARY_OFFSET_EQUALATOR + Binary.objectIdByteLength();
+
+	// field type detour because there are sadly no field literals in Java (yet?).
+	static final Field FIELD_EQUALATOR = getInstanceFieldOfType(EqConstList.class, Equalator.class);
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+
+	@SuppressWarnings({"unchecked",  "rawtypes"})
+	private static Class<EqConstList<?>> handledType()
+	{
+		// no idea how to get ".class" to work otherwise
+		return (Class)EqConstList.class;
+	}
+
+	private static int getBuildItemElementCount(final Binary data)
+	{
+		return X.checkArrayRange(data.getListElementCountReferences(BINARY_OFFSET_LIST));
+	}
+
+	public static BinaryHandlerEqConstList New()
+	{
+		return new BinaryHandlerEqConstList();
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	BinaryHandlerEqConstList()
+	{
+		// binary layout definition
+		super(
+			handledType(),
+			SimpleArrayFields(
+				CustomField(Equalator.class, "equalator")
+			)
+		);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+
+	@Override
+	public final void store(
+		final Binary                          data    ,
+		final EqConstList<?>                  instance,
+		final long                            objectId,
+		final PersistenceStoreHandler<Binary> handler
+	)
+	{
+		// store elements simply as array binary form, leave out space for equalator reference
+		data.storeReferences(
+			this.typeId()                          ,
+			objectId                               ,
+			BINARY_OFFSET_LIST                     ,
+			handler                                ,
+			XCollectionsInternals.getData(instance)
+		);
+
+		// persist equalator and set the resulting oid at its binary place (leading header value)
+		data.store_long(
+			BINARY_OFFSET_EQUALATOR,
+			handler.apply(instance.equality())
+		);
+	}
+
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	@Override
+	public final EqConstList<?> create(final Binary data, final PersistenceLoadHandler handler)
+	{
+		// this method only creates a shallow instance, so the equalator gets set during update like other references.
+		return new EqConstList((Equalator)null, getBuildItemElementCount(data));
+	}
+
+	@Override
+	public final void updateState(final Binary data, final EqConstList<?> instance, final PersistenceLoadHandler handler)
+	{
+		// set equalator instance (must be done on memory-level due to final modifier. Little hacky, but okay)
+		XMemory.setObject(
+			instance,
+			XMemory.objectFieldOffset(FIELD_EQUALATOR),
+			data.readReference(BINARY_OFFSET_EQUALATOR, handler)
+		);
+
+		final Object[] arrayInstance = XCollectionsInternals.getData(instance);
+
+		// Length must be checked for consistency reasons. No clear required.
+		data.validateArrayLength(arrayInstance, BINARY_OFFSET_LIST);
+		data.collectElementsIntoArray(BINARY_OFFSET_LIST, handler, arrayInstance);
+	}
+
+	@Override
+	public final void iterateInstanceReferences(final EqConstList<?> instance, final PersistenceFunction iterator)
+	{
+		iterator.apply(instance.equality());
+
+		final Object[] arrayInstance = XCollectionsInternals.getData(instance);
+		Persistence.iterateReferences(iterator, arrayInstance, 0, arrayInstance.length);
+	}
+
+	@Override
+	public final void iterateLoadableReferences(final Binary data, final PersistenceReferenceLoader iterator)
+	{
+		iterator.acceptObjectId(data.readObjectId(BINARY_OFFSET_EQUALATOR));
+		data.iterateListElementReferences(BINARY_OFFSET_LIST, iterator);
+	}
+
+}

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/org/eclipse/serializer/collections/XCollectionsInternals.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/org/eclipse/serializer/collections/XCollectionsInternals.java
@@ -32,6 +32,7 @@ final class XCollectionsInternals
 		OFFSET_ConstList_data            = getFieldOffset(ConstList       .class, "data"         ),
 		OFFSET_EqBulkList_data           = getFieldOffset(EqBulkList      .class, "data"         ),
 		OFFSET_EqBulkList_size           = getFieldOffset(EqBulkList      .class, "size"         ),
+		OFFSET_EqConstList_data          = getFieldOffset(EqConstList     .class, "data"         ),
 		OFFSET_EqConstHashEnum_size      = getFieldOffset(EqConstHashEnum .class, "size"         ),
 		OFFSET_EqConstHashTable_size     = getFieldOffset(EqConstHashTable.class, "size"         ),
 		OFFSET_EqHashEnum_size           = getFieldOffset(EqHashEnum      .class, "size"         ),
@@ -117,6 +118,11 @@ final class XCollectionsInternals
 	public static Object[] getData(final EqBulkList<?> instance)
 	{
 		return (Object[])XMemory.getObject(instance, OFFSET_EqBulkList_data);
+	}
+
+	public static Object[] getData(final EqConstList<?> instance)
+	{
+		return (Object[])XMemory.getObject(instance, OFFSET_EqConstList_data);
 	}
 	
 	public static Object[] getData(final LimitList<?> instance)

--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryPersistence.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryPersistence.java
@@ -108,6 +108,7 @@ import org.eclipse.serializer.persistence.binary.org.eclipse.serializer.collecti
 import org.eclipse.serializer.persistence.binary.org.eclipse.serializer.collections.BinaryHandlerConstHashTable;
 import org.eclipse.serializer.persistence.binary.org.eclipse.serializer.collections.BinaryHandlerConstList;
 import org.eclipse.serializer.persistence.binary.org.eclipse.serializer.collections.BinaryHandlerEqBulkList;
+import org.eclipse.serializer.persistence.binary.org.eclipse.serializer.collections.BinaryHandlerEqConstList;
 import org.eclipse.serializer.persistence.binary.org.eclipse.serializer.collections.BinaryHandlerEqConstHashEnum;
 import org.eclipse.serializer.persistence.binary.org.eclipse.serializer.collections.BinaryHandlerEqConstHashTable;
 import org.eclipse.serializer.persistence.binary.org.eclipse.serializer.collections.BinaryHandlerEqHashEnum;
@@ -443,6 +444,7 @@ public final class BinaryPersistence extends Persistence
 				BinaryHandlerBulkList.New(controller)   ,
 				BinaryHandlerLimitList.New(controller)  ,
 				BinaryHandlerConstList.New()            ,
+				BinaryHandlerEqConstList.New()          ,
 				BinaryHandlerEqBulkList.New(controller) ,
 				BinaryHandlerHashEnum.New()             ,
 				BinaryHandlerConstHashEnum.New()        ,

--- a/test-fixtures/src/main/java/test/eclipse/serializer/fixtures/TypeEnum.java
+++ b/test-fixtures/src/main/java/test/eclipse/serializer/fixtures/TypeEnum.java
@@ -46,6 +46,7 @@ public enum TypeEnum
     Date(() -> new DateData().fillSampleData(), DateData::new),
     EqBulkList(() -> new EqBulkListData().fillSampleData(), EqBulkListData::new),
     EqConstHashEnum(() -> new EqConstHashEnumData().fillSampleData(), EqConstHashEnumData::new),
+    EqConstList(() -> new EqConstListData().fillSampleData(), EqConstListData::new),
     EqConstHashTable(() -> new EqConstHashTableData().fillSampleData(), EqConstHashTableData::new),
     EqHashEnum(() -> new EqHashEnumData().fillSampleData(), EqHashEnumData::new),
     File(() -> new FileData().fillSampleData(), FileData::new),

--- a/test-fixtures/src/main/java/test/eclipse/serializer/fixtures/types/EqConstListData.java
+++ b/test-fixtures/src/main/java/test/eclipse/serializer/fixtures/types/EqConstListData.java
@@ -1,0 +1,63 @@
+package test.eclipse.serializer.fixtures.types;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+import org.eclipse.serializer.collections.EqConstList;
+import org.eclipse.serializer.equality.Equalator;
+import org.junit.jupiter.api.Assertions;
+
+public class EqConstListData implements BinaryHandlerTestData
+{
+
+    private EqConstList<Integer> value;
+
+    @Override
+    public EqConstListData fillSampleData()
+    {
+        Integer first = 130;
+        Integer second = 300;
+        value = new EqConstList<>(new IntegerEquality(), first, second);
+        return this;
+    }
+
+    EqConstList<Integer> getValue()
+    {
+        return value;
+    }
+
+    @Override
+    public void proveResults(Object o)
+    {
+        Assertions.assertNotNull(o);
+        EqConstListData copy = (EqConstListData) o;
+        assertIterableEquals(this.getValue(), copy.getValue(), "EqConstList");
+    }
+
+    static class IntegerEquality implements Equalator<Integer>
+    {
+        IntegerEquality()
+        {
+        }
+
+        @Override
+        public boolean equal(Integer integer, Integer t1)
+        {
+            return integer.equals(t1);
+        }
+    }
+
+}

--- a/test-fixtures/src/main/java/test/eclipse/serializer/fixtures/types/EqConstListData.java
+++ b/test-fixtures/src/main/java/test/eclipse/serializer/fixtures/types/EqConstListData.java
@@ -45,6 +45,9 @@ public class EqConstListData implements BinaryHandlerTestData
         Assertions.assertNotNull(o);
         EqConstListData copy = (EqConstListData) o;
         assertIterableEquals(this.getValue(), copy.getValue(), "EqConstList");
+
+        // the equalator reference is stored in the handler's leading header slot, so verify it survived the round trip
+        Assertions.assertInstanceOf(IntegerEquality.class, copy.getValue().equality(), "EqConstList equalator");
     }
 
     static class IntegerEquality implements Equalator<Integer>


### PR DESCRIPTION
## Summary

`org.eclipse.serializer.collections.EqConstList` had no dedicated binary type handler, so it could not be serialized/deserialized the way its sibling collections (`ConstList`, `EqBulkList`, `EqConstHashEnum`, …) can. This adds a native `BinaryHandlerEqConstList`.

The persisted binary form mirrors the existing collection-handler pattern: a leading object-id header slot for the `final equalator` reference (offset 0), followed by the simple element reference list.

```
offset 0                    : equalator object-id  (Binary.objectIdByteLength())
offset objectIdByteLength() : element reference list (the E[] data)
```

## Changes

- **`BinaryHandlerEqConstList.java`** (new) — modelled on `BinaryHandlerConstList` (element-list mechanics) and `BinaryHandlerEqConstHashEnum` / `BinaryHandlerEqBulkList` (equalator header + setting the `final` field via `XMemory` on load).
- **`XCollectionsInternals.java`** — added `OFFSET_EqConstList_data` and a `getData(EqConstList<?>)` accessor.
- **`BinaryPersistence.java`** — registered `BinaryHandlerEqConstList.New()` in `defaultCustomHandlers(...)` (no controller, as it is a plain immutable array).
- **`EqConstListData.java`** (new) + **`TypeEnum.java`** — round-trip test fixture, automatically enrolled in the parameterized serializer test.

## Verification

`BasicSerializerTest` passes (70 tests, 0 failures) with the new `EqConstList` case included, confirming a full serialize → deserialize round trip preserves both the element array and the equalator reference.