### PR TITLE
Fix NPE in EqConstList fixture reused by the store reloader test

### DIFF
--- a/test-fixtures/src/main/java/test/eclipse/serializer/fixtures/types/EqConstListData.java
+++ b/test-fixtures/src/main/java/test/eclipse/serializer/fixtures/types/EqConstListData.java
@@ -46,8 +46,13 @@ public class EqConstListData implements BinaryHandlerTestData
         EqConstListData copy = (EqConstListData) o;
         assertIterableEquals(this.getValue(), copy.getValue(), "EqConstList");
 
-        // the equalator reference is stored in the handler's leading header slot, so verify it survived the round trip
-        Assertions.assertInstanceOf(IntegerEquality.class, copy.getValue().equality(), "EqConstList equalator");
+        // The equalator reference is stored in the handler's leading header slot; verify it survived when the list is
+        // populated (serializer round-trip test). This fixture is also reused by the store reloader test, where the
+        // root is reset to its stored empty state and the value is null - skip the equalator check in that case.
+        if(copy.getValue() != null)
+        {
+            Assertions.assertInstanceOf(IntegerEquality.class, copy.getValue().equality(), "EqConstList equalator");
+        }
     }
 
     static class IntegerEquality implements Equalator<Integer>


### PR DESCRIPTION
## Problem

The `EqConstListData` fixture (added in #304) asserts that the deserialized lists equalator survived serialization:

```java
Assertions.assertInstanceOf(IntegerEquality.class, copy.getValue().equality(), "EqConstList equalator");
```

This passes in the serializer round-trip test (`BasicSerializerTest`), where the deserialized copy is fully populated. But the same fixture is reused by the **store** repos `ReloaderSmokeTest.reloadTypeTest`, which:

1. starts a storage with a freshly created (empty) fixture as root,
2. calls `fillSampleData()` **without storing it**,
3. `reloadDeep(...)` resets the root back to its stored empty state (`value == null`),
4. calls `proveResults(...)`.

In that flow `getValue()` returns `null`, so the unconditional `copy.getValue().equality()` throws a `NullPointerException`, breaking the store integration tests (e.g. eclipse-store/store#764 CI, which builds against serializer `main-SNAPSHOT`).

## Fix

Guard the equalator assertion on a populated list. It still runs in the serializer round-trip test (where the list is filled), but is skipped when the reloader resets the root to its stored empty state — matching the null-tolerant convention already used by the sibling `EqBulkListData` fixture.

## Verification

`BasicSerializerTest` still passes (70 tests, 0 failures) with the equalator assertion exercised for the populated `EqConstList`, and the null-dereference that failed the store reloader test is eliminated.