### PR TITLE
Release the flush scheduler when a batch storer is abandoned without close()

### DIFF
--- a/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
+++ b/persistence/binary/src/main/java/org/eclipse/serializer/persistence/binary/types/BinaryStorer.java
@@ -28,6 +28,7 @@ import org.eclipse.serializer.util.BufferSizeProviderIncremental;
 import org.eclipse.serializer.util.logging.Logging;
 import org.slf4j.Logger;
 
+import java.lang.ref.WeakReference;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.Executors;
@@ -1669,7 +1670,7 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			Integer.MAX_VALUE - (256L * 1024 * 1024);
 
 		private final BatchStorer.Controller   controller        ;
-		private final ScheduledExecutorService scheduler         ;
+		private final BackgroundFlusher        flusher           ;
 		private long                           pendingSinceNanos ;
 		private volatile boolean               closed            ;
 
@@ -1724,20 +1725,9 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				);
 			}
 
-			// Validate before creating the executor so a bad checkInterval does not
-			// leak a daemon thread (the constructor would throw after start()).
-			this.scheduler = Executors.newSingleThreadScheduledExecutor(r ->
-			{
-				final Thread t = new Thread(r, "batch-storer-flush");
-				t.setDaemon(true);
-				return t;
-			});
-			this.scheduler.scheduleWithFixedDelay(
-				this::backgroundFlush,
-				millis,
-				millis,
-				TimeUnit.MILLISECONDS
-			);
+			// Validate before creating the flusher so a bad checkInterval does not
+			// leak a daemon thread (the flusher starts its executor in its constructor).
+			this.flusher = new BackgroundFlusher(this, millis);
 		}
 
 		@Override
@@ -1959,23 +1949,7 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 				this.closed = true;
 			}
 
-			this.scheduler.shutdown();
-			try
-			{
-				if(!this.scheduler.awaitTermination(5, TimeUnit.SECONDS))
-				{
-					this.scheduler.shutdownNow();
-					if(!this.scheduler.awaitTermination(5, TimeUnit.SECONDS))
-					{
-						logger.warn("Background flush thread did not terminate within timeout");
-					}
-				}
-			}
-			catch(final InterruptedException e)
-			{
-				this.scheduler.shutdownNow();
-				Thread.currentThread().interrupt();
-			}
+			this.flusher.shutdown();
 
 			// Final flush takes commitLock internally via commit(); must not be held here.
 			if(!this.isEmpty())
@@ -2048,6 +2022,84 @@ public interface BinaryStorer extends PersistenceStorer, PersistenceStoringCallb
 			logger.debug("Flushing batch storer with size = {}", this.size());
 			// pendingSinceNanos is reset inside commit() -> Batching.clear(); no reset needed here.
 			this.commit();
+		}
+
+		/**
+		 * Owns the batch storer's single background-flush thread and holds the storer
+		 * {@link WeakReference weakly}. The periodic task retained by the executor's work queue
+		 * references only this flusher, not the storer, so the executor's (GC-root) worker thread no
+		 * longer pins the storer. An abandoned storer &mdash; dropped without {@link Batching#close()}
+		 * &mdash; therefore becomes collectable together with its chunk buffers, hash slots and
+		 * trusted-object-id set; the next tick then observes the cleared referent and shuts the
+		 * executor down, reclaiming the daemon thread.
+		 * <p>
+		 * Mirrors {@code EvictionManager.IntervalThread} and the JVector {@code BackgroundTaskManager}:
+		 * a strong self-referencing scheduled task would leak the storer for the JVM lifetime.
+		 */
+		private static final class BackgroundFlusher implements Runnable
+		{
+			private final WeakReference<Batching>  storerRef;
+			private final ScheduledExecutorService scheduler;
+
+			BackgroundFlusher(
+				final Batching storer        ,
+				final long     intervalMillis
+			)
+			{
+				super();
+				this.storerRef = new WeakReference<>(storer);
+				this.scheduler = Executors.newSingleThreadScheduledExecutor(r ->
+				{
+					final Thread t = new Thread(r, "batch-storer-flush");
+					t.setDaemon(true);
+					return t;
+				});
+				this.scheduler.scheduleWithFixedDelay(
+					this,
+					intervalMillis,
+					intervalMillis,
+					TimeUnit.MILLISECONDS
+				);
+			}
+
+			@Override
+			public void run()
+			{
+				/*
+				 * Resolve the weakly-held storer. If it has been collected, the storer was abandoned
+				 * without close(): self-terminate so the daemon thread is reclaimed. This runs ON the
+				 * executor thread, so it must NOT awaitTermination() (that would dead-lock).
+				 * The strong reference is not retained in a field, so the next tick can observe a cleared referent.
+				 */
+				final Batching storer = this.storerRef.get();
+				if(storer == null)
+				{
+					this.scheduler.shutdown();
+					return;
+				}
+				storer.backgroundFlush();
+			}
+
+			void shutdown()
+			{
+				this.scheduler.shutdown();
+				try
+				{
+					if(!this.scheduler.awaitTermination(5, TimeUnit.SECONDS))
+					{
+						this.scheduler.shutdownNow();
+						if(!this.scheduler.awaitTermination(5, TimeUnit.SECONDS))
+						{
+							logger.warn("Background flush thread did not terminate within timeout");
+						}
+					}
+				}
+				catch(final InterruptedException e)
+				{
+					this.scheduler.shutdownNow();
+					Thread.currentThread().interrupt();
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

A `Batching` storer (`BinaryStorer.Batching`, the `BatchStorer` implementation) scheduled its background flush as a bound method reference (`this::backgroundFlush`). Because the scheduled task strongly referenced the storer, the executor's worker thread — a GC root — pinned the storer for the lifetime of the JVM. A storer that was dropped without calling `close()` therefore leaked its direct chunk buffers, hash slots and trusted-object-id set, plus one background daemon thread, per abandoned instance. The non-batching storers are held only weakly by the object manager and *are* collectable when abandoned, so drop-and-forget looked safe.

## Fix

Move the executor into a `BackgroundFlusher` helper that holds the storer through a `WeakReference`:

- The periodic task retained by the executor's work queue now references only the flusher (which holds the storer weakly), so the worker thread no longer pins the storer. An abandoned storer becomes garbage-collectable immediately.
- On the next tick the task observes the cleared referent and shuts the executor down — on the executor thread, so without `awaitTermination` (which would dead-lock) — reclaiming the daemon thread.
- `close()` delegates its graceful shutdown (shutdown → `awaitTermination` → `shutdownNow`) to the flusher; the public `close()` behavior, including the final flush, is unchanged.

This mirrors the existing idiom in the tree: `EvictionManager.IntervalThread` and the JVector `BackgroundTaskManager`.

## Testing

A deterministic regression test lives in the **eclipse-store** repository (`test.eclipse.store.various.storer.BatchStorerAbandonedLeakTest`) and covers both symptoms — leaked `batch-storer-flush` threads and the storer instance staying reachable after a full GC sweep (with a non-batch storer as a control). It fails against the previous code and passes with this change. The existing `BatchStorer*` suite continues to pass.

No public API change.
